### PR TITLE
preserve white space in machine comments

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -630,6 +630,9 @@ span.machine_year_man {
 .machine_condition_display_lmx:hover {
   background-color: #dbd9d7;
 }
+.machine_condition_display_lmx span {
+  white-space: pre-wrap;
+}
 .machine_condition_edit_lmx {
   width: 275px;
 }


### PR DESCRIPTION
I finally figured out why the white space (like line breaks) from textareas weren't preserved after you hit "save"! (if you edited an existing comment, the white space in that comment would magically return - indicating that there was something in the machine comment span that was styling the white space).

This will really help with machine comment readability on the website.