### PR TITLE
Machine Condition Site Improvements

### DIFF
--- a/app/controllers/location_machine_xrefs_controller.rb
+++ b/app/controllers/location_machine_xrefs_controller.rb
@@ -51,7 +51,7 @@ class LocationMachineXrefsController < InheritedResources::Base
 
   def render_machine_conditions
     lmx = LocationMachineXref.find(params[:id])
-    render partial: 'locations/render_machine_conditions', locals: { conditions: lmx.machine_conditions.first(6).sort { |x, y| y.created_at <=> x.created_at } }
+    render partial: 'locations/render_machine_conditions', locals: { conditions: lmx.sorted_machine_conditions.first(6), lmx: lmx }
   end
 
   def index

--- a/app/models/location_machine_xref.rb
+++ b/app/models/location_machine_xref.rb
@@ -41,7 +41,7 @@ class LocationMachineXref < ActiveRecord::Base
 
   def sorted_machine_conditions
     # Offset by 1 so that we don't show the current machine condition
-    return self.machine_conditions.order('created_at DESC').offset(1)
+    machine_conditions.order('created_at DESC').offset(1)
   end
 
   def destroy(options = {})

--- a/app/models/location_machine_xref.rb
+++ b/app/models/location_machine_xref.rb
@@ -39,6 +39,11 @@ class LocationMachineXref < ActiveRecord::Base
     )
   end
 
+  def sorted_machine_conditions
+    # Offset by 1 so that we don't show the current machine condition
+    return self.machine_conditions.order('created_at DESC').offset(1)
+  end
+
   def destroy(options = {})
     if location.region.should_email_machine_removal
       Pony.mail(

--- a/app/views/location_machine_xrefs/_update_machine_condition.html.haml
+++ b/app/views/location_machine_xrefs/_update_machine_condition.html.haml
@@ -7,7 +7,7 @@
 %div[lmx, :machine_condition_edit]{:style => 'display:none'}
   = form_tag update_machine_condition_location_machine_xrefs_path(:action => 'update_machine_condition', :id => lmx.id, :region => @region.name), :id => "update_machine_condition_#{lmx.id}", :method => 'get' do
     = hidden_field_tag :id, lmx.id
-    = text_area_tag "new_machine_condition_#{lmx.id}", (lmx.condition.to_s == '') ? '' : lmx.condition, :cols => 20, :rows => 3, :class => 'edit_mode', :placeholder => '(note: if this machine is gone, please just remove it. no need to leave a comment saying it is gone)'
+    = text_area_tag "new_machine_condition_#{lmx.id}", '', :cols => 20, :rows => 3, :class => 'edit_mode', :placeholder => '(note: if this machine is gone, please just remove it. no need to leave a comment saying it is gone)'
     %br/
     = submit_tag 'Save', :id => "save_machine_condition_#{lmx.id}", :class => "save_button"
   = submit_tag 'Cancel', :id => "cancel_machine_condition_#{lmx.id}", :class => "cancel_button"

--- a/app/views/location_machine_xrefs/_update_machine_condition.html.haml
+++ b/app/views/location_machine_xrefs/_update_machine_condition.html.haml
@@ -15,8 +15,6 @@
 :javascript
   $('#update_machine_condition_#{lmx.id}').submit(function () {
     $('#machine_condition_display_#{lmx.id}').html(loadingHTML());
-    $('#machineconditions_container_lmx_#{lmx.id}').css('visibility', 'visible');
-    $('#machineconditions_container_lmx_#{lmx.id}').css('display', 'block');
 
     var form = $(this);
     $.get(form.attr('action'), form.serialize(), function (data) {

--- a/app/views/location_machine_xrefs/_update_machine_condition.html.haml
+++ b/app/views/location_machine_xrefs/_update_machine_condition.html.haml
@@ -15,6 +15,8 @@
 :javascript
   $('#update_machine_condition_#{lmx.id}').submit(function () {
     $('#machine_condition_display_#{lmx.id}').html(loadingHTML());
+    $('#machineconditions_container_lmx_#{lmx.id}').css('visibility', 'visible');
+    $('#machineconditions_container_lmx_#{lmx.id}').css('display', 'block');
 
     var form = $(this);
     $.get(form.attr('action'), form.serialize(), function (data) {

--- a/app/views/locations/_render_machine_conditions.html.haml
+++ b/app/views/locations/_render_machine_conditions.html.haml
@@ -1,3 +1,12 @@
+:javascript
+  $('#machineconditions_container_lmx#{lmx.id}').ready(function(){
+    if ('#{conditions.empty?}' == 'false'){
+      $('#machineconditions_container_lmx_#{lmx.id}').css('display', 'block');
+    }else{
+      $('#machineconditions_container_lmx_#{lmx.id}').css('display', 'none');
+    }
+  });
+
 - conditions.collect! do |mcx|
   %div.machine_condition_new_line{:id => "past_machine_condition_#{mcx.id}"}
     %span{:style => "display:block;"}= "#{mcx.created_at ? mcx.created_at.strftime("%d-%b-%Y") : ''}"

--- a/app/views/machine_conditions/_show_machine_conditions.html.haml
+++ b/app/views/machine_conditions/_show_machine_conditions.html.haml
@@ -1,4 +1,4 @@
-%div[lmx, :machineconditions_container]{:style => "display:#{lmx.machine_conditions.empty? ? 'none' : 'block'}"}
+%div[lmx, :machineconditions_container]{:style => "display:#{lmx.sorted_machine_conditions.empty? ? 'none' : 'block'}"}
   = banner('show_conditions_lmx','SHOW PAST CONDITIONS',lmx)
   %div[lmx, :show_conditions]{:style => 'display:none'}
-    = render :partial => 'locations/render_machine_conditions', :locals => {:conditions => lmx.machine_conditions.first(6).sort { |x,y| y.created_at <=> x.created_at }}
+    = render :partial => 'locations/render_machine_conditions', :locals => {:conditions => lmx.sorted_machine_conditions.first(6), :lmx => lmx}


### PR DESCRIPTION
Fixes following issues:
- Remove old condition when editing machine condition
- Refresh the visibility of the "Show Past Conditions" when needed, such as after no more past conditions exist or after the second condition is added. NOTE: If a machine has no past conditions and you add one the "Show Past Conditions" section will not appear since that is the latest condition. Once you add a second condition then the "Show Past Conditions" section will appear with the previous condition visible.
- No longer show the current condition in past conditions section