### PR TITLE
Add db indexes

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -79,7 +79,12 @@ class PagesController < ApplicationController
       (@links[(rlx.category && !rlx.category.blank?) ? rlx.category : 'Links'] ||= []) << rlx
     end
 
-    @top_machines = LocationMachineXref.region(@region.name).select('machine_id, count(*) as machine_count').group(:machine_id).order('machine_count desc').limit(10)
+    @top_machines = LocationMachineXref
+      .region(@region.name)
+      .select('machine_id, count(*) as machine_count')
+      .group(:machine_id)
+      .order('machine_count desc')
+      .limit(10)
 
     render "#{@region.name}/about" if lookup_context.find_all("#{@region.name}/about").any?
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,6 +2,8 @@ class Event < ActiveRecord::Base
   belongs_to :region
   belongs_to :location
 
+  default_scope { order :id }
+
   scope :region, ->(name) { where(region_id: Region.find_by_name(name.downcase).id).to_a }
 
   attr_accessible :name, :long_desc, :start_date, :end_date, :region_id, :external_link, :category_no, :location_id, :category, :external_location_name, :ifpa_tournament_id, :ifpa_calendar_id

--- a/db/migrate/20151102053730_add_indexes.rb
+++ b/db/migrate/20151102053730_add_indexes.rb
@@ -1,0 +1,50 @@
+class AddIndexes < ActiveRecord::Migration
+  def change
+    change_table :events do |t|
+      t.index :region_id
+      t.index :location_id
+      t.index :ifpa_calendar_id
+      t.index :ifpa_tournament_id
+    end
+
+    change_table :location_machine_xrefs do |t|
+      t.index :user_id
+    end
+
+    change_table :location_picture_xrefs do |t|
+      t.index :location_id
+      t.index :user_id
+    end
+
+    change_table :locations do |t|
+      t.index :zone_id
+      t.index :region_id
+      t.index :location_type_id
+      t.index :operator_id
+    end
+
+    change_table :machine_score_xrefs do |t|
+      t.index :user_id
+    end
+
+    change_table :machines do |t|
+      t.index :machine_group_id
+    end
+
+    change_table :operators do |t|
+      t.index :region_id
+    end
+
+    change_table :region_link_xrefs do |t|
+      t.index :region_id
+    end
+
+    change_table :users do |t|
+      t.index :region_id
+    end
+
+    change_table :zones do |t|
+      t.index :region_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151017212853) do
+ActiveRecord::Schema.define(version: 20151102053730) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,11 @@ ActiveRecord::Schema.define(version: 20151017212853) do
     t.integer  "ifpa_tournament_id"
   end
 
+  add_index "events", ["ifpa_calendar_id"], name: "index_events_on_ifpa_calendar_id", using: :btree
+  add_index "events", ["ifpa_tournament_id"], name: "index_events_on_ifpa_tournament_id", using: :btree
+  add_index "events", ["location_id"], name: "index_events_on_location_id", using: :btree
+  add_index "events", ["region_id"], name: "index_events_on_region_id", using: :btree
+
   create_table "location_machine_xrefs", force: true do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -53,6 +58,7 @@ ActiveRecord::Schema.define(version: 20151017212853) do
 
   add_index "location_machine_xrefs", ["location_id"], name: "index_location_machine_xrefs_on_location_id", using: :btree
   add_index "location_machine_xrefs", ["machine_id"], name: "index_location_machine_xrefs_on_machine_id", using: :btree
+  add_index "location_machine_xrefs", ["user_id"], name: "index_location_machine_xrefs_on_user_id", using: :btree
 
   create_table "location_picture_xrefs", force: true do |t|
     t.integer  "location_id"
@@ -66,6 +72,9 @@ ActiveRecord::Schema.define(version: 20151017212853) do
     t.integer  "photo_file_size"
     t.datetime "photo_updated_at"
   end
+
+  add_index "location_picture_xrefs", ["location_id"], name: "index_location_picture_xrefs_on_location_id", using: :btree
+  add_index "location_picture_xrefs", ["user_id"], name: "index_location_picture_xrefs_on_user_id", using: :btree
 
   create_table "location_types", force: true do |t|
     t.datetime "created_at"
@@ -92,6 +101,11 @@ ActiveRecord::Schema.define(version: 20151017212853) do
     t.integer  "operator_id"
     t.date     "date_last_updated"
   end
+
+  add_index "locations", ["location_type_id"], name: "index_locations_on_location_type_id", using: :btree
+  add_index "locations", ["operator_id"], name: "index_locations_on_operator_id", using: :btree
+  add_index "locations", ["region_id"], name: "index_locations_on_region_id", using: :btree
+  add_index "locations", ["zone_id"], name: "index_locations_on_zone_id", using: :btree
 
   create_table "machine_conditions", force: true do |t|
     t.text     "comment"
@@ -120,6 +134,7 @@ ActiveRecord::Schema.define(version: 20151017212853) do
   end
 
   add_index "machine_score_xrefs", ["location_machine_xref_id"], name: "index_machine_score_xrefs_on_location_machine_xref_id", using: :btree
+  add_index "machine_score_xrefs", ["user_id"], name: "index_machine_score_xrefs_on_user_id", using: :btree
 
   create_table "machines", force: true do |t|
     t.string   "name"
@@ -133,6 +148,8 @@ ActiveRecord::Schema.define(version: 20151017212853) do
     t.integer  "ipdb_id"
   end
 
+  add_index "machines", ["machine_group_id"], name: "index_machines_on_machine_group_id", using: :btree
+
   create_table "operators", force: true do |t|
     t.string   "name"
     t.integer  "region_id"
@@ -142,6 +159,8 @@ ActiveRecord::Schema.define(version: 20151017212853) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  add_index "operators", ["region_id"], name: "index_operators_on_region_id", using: :btree
 
   create_table "rails_admin_histories", force: true do |t|
     t.string   "message"
@@ -164,6 +183,8 @@ ActiveRecord::Schema.define(version: 20151017212853) do
     t.integer "region_id"
     t.integer "sort_order"
   end
+
+  add_index "region_link_xrefs", ["region_id"], name: "index_region_link_xrefs_on_region_id", using: :btree
 
   create_table "regions", force: true do |t|
     t.string   "name"
@@ -208,6 +229,7 @@ ActiveRecord::Schema.define(version: 20151017212853) do
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+  add_index "users", ["region_id"], name: "index_users_on_region_id", using: :btree
 
   create_table "zones", force: true do |t|
     t.string   "name"
@@ -217,5 +239,7 @@ ActiveRecord::Schema.define(version: 20151017212853) do
     t.string   "short_name"
     t.boolean  "is_primary"
   end
+
+  add_index "zones", ["region_id"], name: "index_zones_on_region_id", using: :btree
 
 end

--- a/spec/models/machine_spec.rb
+++ b/spec/models/machine_spec.rb
@@ -23,7 +23,7 @@ describe Machine do
     it 'should return this machine and all machines group together with it' do
       sassy_champ = FactoryGirl.create(:machine, name: 'Sassy Championship Edition', machine_group: @machine_group)
 
-      expect(@m.all_machines_in_machine_group).to eq([@m, sassy_champ])
+      expect(@m.all_machines_in_machine_group).to include(@m, sassy_champ)
     end
   end
 end

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -131,7 +131,7 @@ HERE
       l = FactoryGirl.create(:location, region: @r)
       l2 = FactoryGirl.create(:location, region: @r)
 
-      expect(@r.machineless_locations).to eq([l, l2])
+      expect(@r.machineless_locations).to include(l, l2)
     end
   end
 


### PR DESCRIPTION
This PR adds indexes for foreign keys and addresses #414. This should hopefully improve site performance a bit.

A couple of notes. Since we're adding an index that is commonly used for scopes (i.e., the `region_id` index in `locations` table), Postgres changes the sort order a bit. I.e., when you run `SELECT * FROM locations WHERE region_id = 1`, Postgres was returning rows in _descending_ order based on `location_id` since it was using the btree index on `region_id`. As a result, we have either two options:

+ Sprinkle in a bunch of `order` clauses on associations. (i.e., `has_many :users, -> { order 'users.id' }`)
+ Do not rely on default sorting order unless necessary. (I.e., specify `order('users.id')` within application logic).

I kind of prefer the last one, but those changes would have been a bit more complicated.

All tests pass locally. Let me know what you think.

Cheers!