### PR TITLE
styled username, and display update date for all users

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -1309,13 +1309,19 @@ input#initials {
   border-top: 1px solid #CAC6C6;
   border-bottom: 1px solid #CAC6C6;
 }
-.confirm_location span {
+.confirm_location span.last_updated {
   font-style: normal;
-  font-size: 14px;
+  font-size: 15px;
   font-weight: bold;
   display: block;
   padding: 15px 5px;
   text-align: right;
+  color: #6E5335;
+}
+.confirm_location span .last_updated_username {
+  color: #441e56;
+  font-family: 'JohnDoe',Helvetica,Arial,sans-serif;
+  font-size: 15px;
 }
 .confirm_location:hover {
   cursor: pointer;
@@ -1324,14 +1330,14 @@ input#initials {
   color: #441e56;
   line-height: 20px;
   background: #F3F2F2;
-  margin: 5px 0;
+  margin: 0;
   font-size: 12px;
 }
 .confirm_location_button img {
   height: 40px;
   float: left;
   cursor: pointer;
-  margin: 0 5px;
+  margin: 5px 5px;
 }
 .confirm_location_button:hover:after {
   content: "Confirm location is up to date";

--- a/app/views/locations/_render_desc.html.haml
+++ b/app/views/locations/_render_desc.html.haml
@@ -1,18 +1,24 @@
 %div[l, :desc_show]
   %span.location_actual_description= (l.description.to_s == '') ? '' : l.description 
   .clear
-- if user_signed_in?
-  %div[l, :desc_edit]{:style => 'display:none'}
+%div[l, :desc_edit]{:style => 'display:none'}
+  - if user_signed_in?
     = form_tag update_desc_locations_path(:action => 'update_desc', :id => l.id, :region => @region.name), :id => "update_desc_#{l.id}", :method => 'get' do
       = hidden_field_tag :id, l.id
       = text_area_tag "new_desc_#{l.id}", (l.description.to_s == '') ? 'Update location description/hours/etc' : l.description, :cols => 20, :rows => 3, :class => 'edit_mode'
       %br/
       = submit_tag 'Save', :class => "save_button", :id => "save_desc_#{l.id}"
     = submit_tag 'Cancel', :id => "desc_cancel_#{l.id}", :class => "cancel_button"
-  %div{id: "confirm_location_#{l.id}", :class => "confirm_location"}
-    %div{:class => "confirm_location_button", :id => "confirm_location_button_#{l.id}"}
+%div{id: "confirm_location_#{l.id}", :class => "confirm_location"}
+  %div{:class => "confirm_location_button", :id => "confirm_location_button_#{l.id}"}
+    - if user_signed_in?
       =image_tag('confirm.png', :alt => 'Confirm Location is Up To Date')
-    %span{:id => "last_updated_location_#{l.id}"} #{l.date_last_updated ? "Location last updated: #{l.date_last_updated}" : ''} #{l.last_updated_by_user ? "by #{l.last_updated_by_user.username}" : ''}
+  %span.last_updated{:id => "last_updated_location_#{l.id}"} 
+    #{l.date_last_updated ? "Location last updated: #{l.date_last_updated}" : ''} 
+    #{l.last_updated_by_user ? "by " : ''}
+    %span.last_updated_username
+      #{l.last_updated_by_user ? "#{l.last_updated_by_user.username}" : ''}
+
 
 :javascript
   $('#confirm_location_button_#{l.id}').click(function () {

--- a/app/views/locations/_render_last_updated.html.haml
+++ b/app/views/locations/_render_last_updated.html.haml
@@ -1,1 +1,4 @@
-Location last updated: #{l.date_last_updated} #{l.last_updated_by_user ? "by #{l.last_updated_by_user.username}" : ''}
+Location last updated: #{l.date_last_updated} 
+#{l.last_updated_by_user ? "by " : ''}
+%span.last_updated_username
+  #{l.last_updated_by_user ? "#{l.last_updated_by_user.username}" : ''}


### PR DESCRIPTION
My edits to app/views/locations/_render_desc.html.haml seem really inelegant.

The goals:
1) show the location update date for logged out users (but not the update icon). But there's an if statement around the entire thing. I tried to put "if logged in || if not logged in" within that first if statement, and that didn't work. So instead, I moved the first if statement down one line, so the opening div is outside of it. Further below, I hid the update icon with another if statement. But again, I had to put it one line below the opening icon div (line 14). If I put it before that confirm_location_button div, then the update message wouldn't show up for logged out users.

2) in the "by username" text, I only wanted the username to be a different color/font. So I made two "if logged in" statements. One for the "by" and one for "username". That way, I could wrap a span around just the "username." I also moved each step in the IFs to new lines.

Tell me if any of that is too janky. 

I'm still working on styling it (esp for mobile). And there's hover behavior over that div even when logged out. I'll look into that.