### PR TITLE
on mobile, fixed and more compact header, other minor header styles

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -119,7 +119,8 @@ li a:hover {
   width: 270px;
 }
 #login label.password,
-#login label.email {
+#login label.email,
+#login label.string {
   display: block;
 }
 #login label.boolean {
@@ -200,9 +201,21 @@ p.notice {
 #flash_recaptcha_error {
   display: none;
 }
-#flash-message {
+#flash-message.flash_home {
   width: 100%;
   float: left;
+}
+#flash-message.flash_region {
+  width: 100%;
+  float: none;
+}
+#flash-message.flash_region #flash_notice,
+#flash-message.flash_region #flash_alert {
+  position: absolute;
+  bottom: 0;
+  margin: 0;
+  width: 100%;
+  max-width: 100%;
 }
 #flash-message #flash_notice,
 #flash-message #flash_alert {
@@ -338,7 +351,7 @@ div.pick_a_map .store_header {
   width: 144px;
   font-size: 24px;
   text-shadow: 1px 1px 5px #CCCCCC;
-  line-height: 54px;
+  line-height: 46px;
   position: absolute;
   text-align: center;
   border: 4px solid #d6c0aa;
@@ -366,6 +379,7 @@ div.pick_a_map .store_header {
   line-height: 18px;
 }
 #header .menu_link ul li a {
+  text-align: left !important;
   padding: 5px 6px;
   float: none;
   display: block;
@@ -374,6 +388,13 @@ div.pick_a_map .store_header {
   vertical-align: middle;
   height: 24.5px;
   width: auto !important;
+  font-size: 12px;
+  line-height: 11px;
+  background-color: #ece2d8;
+  text-shadow: 1px 1px 5px #CCCCCC;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
 }
 #header .menu_link ul li a:hover {
   color: #441e56;
@@ -462,8 +483,7 @@ div.pick_a_map .store_header {
   vertical-align: middle;
   margin-bottom: 2px;
 }
-.apps_header, .blog_header, .store_header,
-#header .menu_link ul li a {
+.apps_header, .blog_header, .store_header {
   font-size: 12px;
   line-height: 11px;
   float: left;

--- a/app/assets/stylesheets/mediaqueries.css
+++ b/app/assets/stylesheets/mediaqueries.css
@@ -50,7 +50,7 @@
   div.pick_a_map .login_home {
     font-size: 12px;
     width: 75px;
-    margin-top: 0;
+    margin-top: -5px;
     line-height: 21px;
   }
   .login {
@@ -96,7 +96,7 @@
 
 }
 
-@media (max-width: 1120px) {
+@media (max-width: 1130px) {
   div.pick_a_map .apps_header, div.pick_a_map .blog_header, 
   div.pick_a_map .store_header, div.pick_a_map .geo_header {
     font-size: 12px;
@@ -126,7 +126,7 @@
   .login_region a {
     font-size: 12px;
     line-height: 23px;
-    padding: 3px;
+    padding: 0;
     text-align: center;
   }
   .login_region {
@@ -134,7 +134,7 @@
     width: 65px;
     padding: 0;
     line-height: 20px;
-    text-align: right;
+    text-align: center;
   }
   .login_slash {
     display: none;

--- a/app/assets/stylesheets/mediaqueries.css
+++ b/app/assets/stylesheets/mediaqueries.css
@@ -56,15 +56,12 @@
   .login {
     padding: 2px 2px;
   }
-  .login_slash {
-    display: none;
-  }
 }
 
 @media (max-width: 965px) { 
 
   #header span.menu_link {
-    line-height: 51px;
+    line-height: 46px;
     width: 45px !important;
     font-size: 14px !important;
     border-right: 4px solid #D6C0AA;
@@ -121,14 +118,26 @@
 }
 
 @media (max-width: 1065px) {
-  .login_region {
+  .login_region a.loggedin {
+    font-size: 15px;
+    line-height: 26px;
+    padding-top: 10px;
+  }
+  .login_region a {
     font-size: 12px;
-    width: 75px;
-    margin-top: 0;
     line-height: 23px;
     padding: 3px;
     text-align: center;
-    border: 4px solid #D6C0AA;
+  }
+  .login_region {
+    margin-top: 0;
+    width: 65px;
+    padding: 0;
+    line-height: 20px;
+    text-align: right;
+  }
+  .login_slash {
+    display: none;
   }
 }
 
@@ -138,7 +147,7 @@
     width: 75px;
     margin-top: 0;
     line-height: 13px;
-    padding: 6px 6px;
+    padding: 3px 4px 4px;
     text-align: center;
   }
 }

--- a/app/assets/stylesheets/mobile-application.css.erb
+++ b/app/assets/stylesheets/mobile-application.css.erb
@@ -4,19 +4,33 @@
 #page {
   height: auto;
 }
+#page.page_home {
+  height: 80px;
+}
 #lookup_map, #container {
   margin: 0 auto;
   width: auto;
   min-width: 320px;
 }
 #header {
-  position: relative;
+  position: fixed;
   box-shadow: none;
-  width: auto;
+  width: 100%;
   min-width: 320px;
   height: auto;
   background-color: #ece2d8;
   margin: 0 auto;
+  padding-top: 2px;
+  z-index: 600;
+}
+#header_lower {
+  position: relative;
+  box-shadow: none;
+  width: 100%;
+  min-width: 320px;
+  height: auto;
+  background-color: #ece2d8;
+  margin: 30px auto 0;
 }
 #header a img {
   float: none;
@@ -31,31 +45,31 @@
   line-height: 18px;
 }
 #menu {
-  margin: 0 0 5px;
-  display: block;
+  margin: 2px 5px 0;
+  float: left;
   height: 25px;
   font-size: 24px;
-  text-align: center;
+  text-align: left;
 }
 #header #nav {
   display: block;
+  float: left;
 }
 #header #nav.js {
   display: none;
 }
 #header span.menu_link ul {
   display: inline-block;
+  text-align: left;
   margin: 0 auto 10px;
-  padding: 0 10px;
+  padding: 0;
   float: none;
   width: 100%;
-  min-width: 320px;
   background-color: #ece2d8;
   visibility: visible;
   box-shadow: none;
   -moz-box-shadow: none;
   -webkit-box-shadow: none;
-  width: auto !important;
 }
 #header span.menu_link ul:before,
 #header span.menu_link ul span {
@@ -90,10 +104,11 @@
   margin: 0 auto;
   width: 100%;
   font-size: 20px;
+  display: block;
+  position: relative !important;
 }
 .closest_locations, .login_region {
   font-size: 22px;
-  border: 2px solid #d6c0aa;
   background-color: #f7f3ef;
   width: auto;
   float: none !important;
@@ -117,14 +132,27 @@
 .confirm_location span.last_updated {
   padding: 8px 5px;
 }
-#header span.region_name_page a {
+span.region_name_page a {
   font-size: 30px;
+}
+span.region_name_page {
+  background: #ece2d8;
 }
 
 #header.header_home, #header.header_image_home {
   min-width: 320px;
   padding: 0;
   height: auto;
+}
+
+#header a img.header_image {
+  float: right;
+  margin: 2px 0 0;
+  width: 180px;
+}
+
+#header a img.header_image_login {
+  width: 200px;
 }
 
 .header_image_a {
@@ -144,31 +172,53 @@
 div.pick_a_map {
   padding-top: 0;
 }
-.apps_header, .blog_header, .store_header, .geo_header, .login_home, .closest_locations {
+.apps_header, .blog_header, .store_header, .closest_locations {
   width: 100% !important;
   float: none;
   padding: 4px 0 4px;
-  border-right: 2px solid #d6c0aa;
-  border-left: 2px solid #d6c0aa;
   text-align: center;  
   border-top: none;
+  border-right: none;
+  border-left: none;
   font-size: 18px !important;
   line-height: 24px !important;
+}
+
+.login_home, .geo_header_wrapper {
+  width: auto;
+  float: right;
+  font-size: 14px !important;
+  border: none !important;
+  padding: 0;
+  margin: 3px 8px;
+}
+
+.login_home a {
+  border: 1px solid #c2a681;
+  padding: 3px;
+  background: #f9f7f3;
+}
+
+.geo_header_wrapper {
+  margin: 2px 0;
+}
+
+.geo_header_wrapper a {
+  border: 1px solid #c2a681;
+  padding: 3px;
+  background: #f9f7f3;
 }
 
 div.pick_a_map .login_home {
   margin: 0;
 }
+
 div.pick_a_map .blog_header {
     border-left: 2px solid #d6c0aa;
 }
 
 .closest_locations {
   margin: 0;
-}
-
-.closest_locations, .geo_header, .login_home {
-  border-bottom: 2px solid #d6c0aa;
 }
 
 .map_summary {
@@ -178,7 +228,7 @@ div.pick_a_map .blog_header {
 #welcome {
   width: auto;
   min-width: 320px;
-  margin-top: 10px;
+  margin-top: 5px;
 }
 
 #map {
@@ -221,6 +271,10 @@ div.pick_a_map .blog_header {
 #intro p, #intro .dark, #intro .darkb {
   font-size: 18px;
   line-height: 22px;
+}
+
+#intro p {
+  margin-top: 0;
 }
 
 .local_logo img {
@@ -566,12 +620,15 @@ div.machine_condition_text {
   right: 0;
 }
 
-#flash-message {
-  float: none;
-}
-#flash-message #flash_notice {
+#flash-message #flash_notice, #flash-message #flash_alert {
   width: auto;
-  margin: 10px auto 10px;
+  max-width: 100%;
+  margin: 70px auto 10px;
+}
+#flash-message.flash_region #flash_notice,
+#flash-message.flash_region #flash_alert {
+  margin: 0px auto 10px;
+  position: relative;
 }
 
 #file_chooser_button {
@@ -750,16 +807,12 @@ input#score, input#initials {
 }
 
 #login {
-  margin: 10px auto 0;
-}
-
-.login { 
-  margin: 0;
+  margin: 5px auto 0;
   width: auto;
 }
 
-.login_slash {
-  display: inline;
+#login h2 {
+  margin-top: 10px;
 }
 
 .login_why_outer {
@@ -770,6 +823,11 @@ input#score, input#initials {
 .login_why_inner {
   width: auto;
   float: none;
+}
+
+.login_why_inner p {
+  margin-top: 0;
+  margin-bottom: 0;
 }
 
 .login_new_div {
@@ -811,8 +869,36 @@ p.notice {
 
 @media (max-width: 320px) {
 
+  #header {
+    width: auto;
+  }
   .map_summary {
     width: 137px;
+  }
+  #header a img.header_image {
+    float: right;
+    margin: 2px 0 0;
+    width: 160px;
+  }
+  #header a img.header_image_login {
+    width: 220px;
+    margin: 0;
+  }
+  .login_home, .geo_header_wrapper {
+    font-size: 12px !important;
+    margin: 3px 3px;
+  }
+  .geo_header_wrapper {
+    margin-top: 2px;
+  }
+  #intro p {
+    font-size: 16px;
+  }
+  #header #nav {
+    float: none;
+  }
+  #header .menu_link ul li.first_header_link {
+    margin-top: 30px;
   }
 
 }

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -27,10 +27,10 @@
 
   %body{ :onload => defined?(@region) ? "setSearchSections(#{@region.available_search_sections}); switchSection('#{(@region.default_search_type && !@region.default_search_type.empty?) ? @region.default_search_type : 'location'}'); initSearch('#{@region.name.downcase}', '#{params['by_operator_id']}', '#{params['by_location_id']}', '#{params['by_location_type_id']}', '#{params['by_zone_id']}', '#{params['by_machine_id']}','#{params['by_ipdb_id']}','#{params['by_city_id']}', '#{params['by_machine_group_id']}', '#{params['show_location_distance']}', '#{params['lat']}', '#{params['lon']}');" : nil }
     #container
-      #page
+      #page{:class => "#{@region ? '' : 'page_home'}"}
         = render :partial => 'pages/header'
         .clear
-        #flash-message
+        #flash-message{:class => "#{@region ? 'flash_region' : 'flash_home'}"}
           - flash.each do |name, msg|
             = content_tag :div, msg, :id => "flash_#{name}"
 

--- a/app/views/pages/_header.html.haml
+++ b/app/views/pages/_header.html.haml
@@ -1,24 +1,91 @@
-#header{:class => "#{@region ? '' : 'header_home'}"}
-  =link_to image_tag('pinballmapcom.jpg', :class => "#{@region ? 'header_image' : 'header_image_home'}", :alt => 'Pinball Map Logo'), root_path
-  - if (@region)
-    %div{:class => "header_buttons"}
-      %div.login.login_region
-        %span.darkb
-          - if !user_signed_in?
-            = link_to 'Log In', "http://#{request.host_with_port}/users/sign_in"
-            %span.login_slash /
-            = link_to 'Sign Up', "http://#{request.host_with_port}/users/sign_up"
-          - else 
-            = link_to 'Log Out', "http://#{request.host_with_port}/users/sign_out"
-      %span.darkb.closest_locations{:style => "float:right;", :onclick => "findClosestLocations('#{@region.name}')"}
-        = link_to 'Show Closest Locations', '#', {:id => 'find_closest_locations'}
-      %div.region_logo_dropdown
-        %div.other_regions
-          %span.region_name_page
-            =link_to "#{@region.full_name}", region_homepage_path
-        - if !mobile_device?
-          %ul.other_regions_list= other_regions_html(@region) 
+- if !mobile_device?
+  #header{:class => "#{@region ? '' : 'header_home'}"}
+    =link_to image_tag('pinballmapcom.jpg', :class => "#{@region ? 'header_image' : 'header_image_home'}", :alt => 'Pinball Map Logo'), root_path
+    - if (@region)
+      %div{:class => "header_buttons"}
+        %div.login.login_region
+          %span.darkb
+            - if !user_signed_in?
+              = link_to 'Log In', "http://#{request.host_with_port}/users/sign_in"
+              %span.login_slash /
+              = link_to 'Sign Up', "http://#{request.host_with_port}/users/sign_up"
+            - else 
+              = link_to 'Log Out', "http://#{request.host_with_port}/users/sign_out", :class => "loggedin"
+        %span.darkb.closest_locations{:style => "float:right;", :onclick => "findClosestLocations('#{@region.name}')"}
+          = link_to 'Show Closest Locations', '#', {:id => 'find_closest_locations'}
+        %div.region_logo_dropdown
+          %div.other_regions
+            %span.region_name_page
+              =link_to "#{@region.full_name}", region_homepage_path
+          - if !mobile_device?
+            %ul.other_regions_list= other_regions_html(@region) 
+        %span.menu_link
+          %ul#nav
+            %li.first_header_link=link_to 'About', about_path
+            %li=link_to 'Events', events_path
+            %li=link_to 'Suggest Location', suggest_path
+            %li=link_to 'High Scores', high_rollers_path
+            %li=link_to 'Location RSS', "/#{params[:region]}/location_machine_xrefs.rss", {:class => 'feed_icon'}
+            %li=link_to 'Score RSS', "/#{params[:region]}/machine_score_xrefs.rss", {:class => 'feed_icon'}
+            %li=link_to 'Event RSS', "/#{params[:region]}/events.rss", {:class => 'feed_icon'}
+            %li.darkb.blog_header_region
+              = link_to 'Blog', 'http://blog.pinballmap.com'
+            %li.darkb.store_header_region
+              = link_to 'T-Shirts', store_path
+            %li.darkb.blog_header_region
+              =link_to 'App', apps_path
+    - else
+      %div{:class => "pick_a_map"}
+        %span.darkb.blog_header
+          = link_to 'Blog', 'http://blog.pinballmap.com'
+        %span.darkb.apps_header
+          = link_to 'App', apps_path
+        %span.darkb.store_header
+          = link_to 'T-Shirts', store_path
+        %div.login.login_home
+          %span.darkb
+            - if !user_signed_in?
+              = link_to 'Log In', "http://#{request.host_with_port}/users/sign_in"
+              %span.login_slash /
+              = link_to 'Sign Up', "http://#{request.host_with_port}/users/sign_up"
+            - else 
+              = link_to 'Log Out', "http://#{request.host_with_port}/users/sign_out"
+        %span.darkb.geo_header{:onclick => "findClosestRegion()"}
+          = link_to 'Find Your Closest Map', '#'
+- else
+  #header{:class => "#{@region ? '' : 'header_home'}"}
+    - if !(@region)
+      =link_to image_tag('pinballmapcom.jpg', :class => "#{@region ? 'header_image' : 'header_image_home'}", :alt => 'Pinball Map Logo'), root_path
       %span.menu_link
+        %div.login.login_home
+          %span.darkb
+            - if !user_signed_in?
+              = link_to 'Log In', "http://#{request.host_with_port}/users/sign_in"
+              %span.login_slash /
+              = link_to 'Sign Up', "http://#{request.host_with_port}/users/sign_up"
+            - else 
+              = link_to 'Log Out', "http://#{request.host_with_port}/users/sign_out"
+        %div.geo_header_wrapper
+          %span.darkb{:onclick => "findClosestRegion()"}
+          = link_to 'Find Your Closest Map', '#'
+        %ul#nav
+          %li.first_header_link= link_to 'Blog', 'http://blog.pinballmap.com'
+          %li.first_header_link= link_to 'App', apps_path
+          %li.first_header_link= link_to 'T-Shirts', store_path
+    - else
+      %span.menu_link
+        %div.login.login_home
+          %span.darkb
+            - if !user_signed_in?
+              = link_to 'Log In', "http://#{request.host_with_port}/users/sign_in"
+              %span.login_slash /
+              = link_to 'Sign Up', "http://#{request.host_with_port}/users/sign_up"
+            - else 
+              = link_to 'Log Out', "http://#{request.host_with_port}/users/sign_out"
+        - if user_signed_in?
+          =link_to image_tag('pinballmapcom.jpg', :class => "#{@region ? 'header_image' : 'header_image_home'} header_image_login", :alt => 'Pinball Map Logo'), root_path
+        - else 
+          =link_to image_tag('pinballmapcom.jpg', :class => "#{@region ? 'header_image' : 'header_image_home'}", :alt => 'Pinball Map Logo'), root_path
         %ul#nav
           %li.first_header_link=link_to 'About', about_path
           %li=link_to 'Events', events_path
@@ -33,24 +100,16 @@
             = link_to 'T-Shirts', store_path
           %li.darkb.blog_header_region
             =link_to 'App', apps_path
-  - else
-    %div{:class => "pick_a_map"}
-      %span.darkb.blog_header
-        = link_to 'Blog', 'http://blog.pinballmap.com'
-      %span.darkb.apps_header
-        = link_to 'App', apps_path
-      %span.darkb.store_header
-        = link_to 'T-Shirts', store_path
-      %div.login.login_home
-        %span.darkb
-          - if !user_signed_in?
-            = link_to 'Log In', "http://#{request.host_with_port}/users/sign_in"
-            %span.login_slash /
-            = link_to 'Sign Up', "http://#{request.host_with_port}/users/sign_up"
-          - else 
-            = link_to 'Log Out', "http://#{request.host_with_port}/users/sign_out"
-      %span.darkb.geo_header{:onclick => "findClosestRegion()"}
-        = link_to 'Find Your Closest Map', '#'
+  - if (@region)
+    #header_lower
+      %span.darkb.closest_locations{:style => "float:right;", :onclick => "findClosestLocations('#{@region.name}')"}
+        = link_to 'Show Closest Locations', '#', {:id => 'find_closest_locations'}
+      %div.region_logo_dropdown
+        %div.other_regions
+          %span.region_name_page
+            =link_to "#{@region.full_name}", region_homepage_path
+
+        
 
 :javascript
   $().ready(function() {


### PR DESCRIPTION
Lotta header changes here (mostly on mobile). Tell me how you think it looks/works. I tested it with lots of different devices (emulations), and it seems good/functional. The overall idea is a small fixed header that is always present on the screen and contains the menu link and the login/out links. I smooshed the pbm logo in there.

On the home page, the header contains a full width pbm logo, and the menu items below it. Both lines are fixed.

I don't think this takes up too much screen real estate. And this seems like common practice - lots of websites do it these days (though the menu isn't always fixed. github is an example of a non-fixed version; lyft is an example of a fixed version).

Only outstanding issue is the flash message stays on the screen forever unless you go to another page. But I made an issue for adding a timer to that. I dunno exactly why, but styling that flash message is tricky! For the desktop site, I just put in on the bottom of the page. I might also do that for mobile, once it's a timed message.
