### PR TITLE
fixed a javascript mistake for editing meta and description

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -1663,7 +1663,6 @@ div.comment_image .comment_image:active {
 .desc_show_location {
   padding-bottom: 5px;
   width: 100%;
-  cursor: pointer;
 }
 .desc_edit_location {
   padding: 0 10px 5px 10px;

--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -719,8 +719,9 @@ span.region_name_page {
 #form .search_field_container input.lookup_search_input {
   border: none;
   margin: 0;
-  height: auto;
+  height: 24px;
   padding-left: 4px;
+  font-family: Helvetica;
 }
 .location_search {
   margin-left: 2px;
@@ -823,7 +824,7 @@ span.region_name_page {
 }
 #by_type_id, #by_operator_id, #by_location_id, #by_machine_id, #by_zone_id, #by_city_id {
   width: 200px;
-  font-size: 16px;
+  font-size: 16px !important;
 }
 .active_section_link {
   background-color: #303030 !important;
@@ -1124,11 +1125,11 @@ form.remove_machine_condition {
 .add_picture_location span.info, .show_machines_location span.info, .add_machine_location span.info {
   padding: 0 0 5px 0;
 }
-.add_picture_location {
+.add_picture_location, .add_machine_location {
   background-color: #EFEFEF;
 }
-.add_machine_location {
-  background-color: #EFEFEF;
+.add_machine_location form select option {
+  font-size: 16px;
 }
 .show_machines_location {
   background-color: #EEEEEE;
@@ -1221,6 +1222,7 @@ br.clear {
   border-radius: 2px;
   -moz-border-radius: 2px;
   -webkit-border-radius: 2px;
+  font-size: 15px;
 }
 .add_picture_location input.submit_picture {
   width: auto;
@@ -1340,6 +1342,7 @@ input.search,
   margin: 0 0 0 4px;
   background: #FFFFFF;
   color: #000000;
+  font-family: Helvetica;
 }
 .lookup_search_select {
   width: 450px;
@@ -1430,18 +1433,20 @@ input#initials {
   line-height: 24px;
   height: 24px;
 }
-.location_type, .operator {
+.location_type, .operator, .operator a {
   color: #666666;
   font-size: 16px;
   padding: 2px 0 6px 4px;
   line-height: 16px;
-  font-weight: normal !important;
+}
+.operator a:hover {
+  color: #F53240;
 }
 .location_type li {
   margin-top: 5px;
 }
 .edit_mode {
-  font-size: 16px;
+  font-size: 15px;
   font-family: Helvetica,Arial,sans-serif;
 }
 .desc_edit_location .edit_mode {
@@ -2455,9 +2460,15 @@ border: 1px solid #D56C24;
 /** Autofill Override **/
 
 .ui-menu .ui-menu-item {
-  font-size: 11px;
+  font-size: 16px;
+  padding: 1px 1em 1px .4em;
+  font-family: Helvetica;
 }
 .ui-menu .ui-menu-item:hover {
   border: none;
   margin: 0;
+}
+.ui-autocomplete {
+  max-height: 300px;
+  overflow-y: scroll;
 }

--- a/app/assets/stylesheets/mobile-application.css.erb
+++ b/app/assets/stylesheets/mobile-application.css.erb
@@ -265,6 +265,9 @@ div.pick_a_map {
   .login_home {
     margin: 2px 2px 0 0;
   }
+  .metadata_edit_location form select, .metadata_edit_location input.edit_mode {
+    width: 160px !important;
+  }
 }
 
 @media only screen and (max-width: 320px)
@@ -277,7 +280,7 @@ div.pick_a_map {
     margin-top: 4px;
   }
   .pintips a {
-    font-size: 16px;
+    font-size: 16px !important;
   }
 }
 
@@ -682,7 +685,7 @@ div.machine_condition_text {
 }
 
 .metadata_edit_location {
-  font-size: 13px;
+  font-size: 15px;
 }
 
 .machine_condition_edit_lmx {

--- a/app/views/locations/_render_desc.html.haml
+++ b/app/views/locations/_render_desc.html.haml
@@ -1,5 +1,5 @@
 %div[l, :desc_show]
-  %span.location_actual_description= (l.description.to_s == '') ? '' : l.description 
+  %span.location_actual_description= (l.description.to_s == '') ? '' : l.description
   .clear
 %div[l, :desc_edit]{:style => 'display:none'}
   - if user_signed_in?
@@ -14,8 +14,8 @@
     %div{:class => "confirm_location_button", :id => "confirm_location_button_#{l.id}"}
       - if user_signed_in?
         %span.confirm_button
-    %span.last_updated{:id => "last_updated_location_#{l.id}"} 
-      #{l.date_last_updated ? "Location last updated: #{l.date_last_updated.strftime("%b-%d-%Y")}" : ''} 
+    %span.last_updated{:id => "last_updated_location_#{l.id}"}
+      #{l.date_last_updated ? "Location last updated: #{l.date_last_updated.strftime("%b-%d-%Y")}" : ''}
       #{l.last_updated_by_user ? "by " : ''}
       %span.last_updated_username
         #{l.last_updated_by_user ? "#{l.last_updated_by_user.username}" : ''}
@@ -41,7 +41,7 @@
 
 - if user_signed_in?
   :javascript
-    $('#desc_cancel_#{l.id}, #desc_show_location_#{l.id}, .location_description .comment_image').click(function () {
+    $('#desc_cancel_#{l.id}, #location_detail_location_#{l.id} .location_description .comment_image').click(function () {
       $('#desc_show_location_#{l.id}').toggle();
       $('#desc_edit_location_#{l.id}').toggle();
     });

--- a/app/views/locations/_render_update_metadata.html.haml
+++ b/app/views/locations/_render_update_metadata.html.haml
@@ -3,17 +3,18 @@
     %li.address_full= link_to l.phone, "tel:" + l.phone, :type => 'tel'
     .clear
   - else
-    %li.phone= l.phone
-    .clear
-  - if l.website
+    - if l.phone?
+      %li.phone= l.phone
+      .clear
+  - if l.website?
     %li.website= link_to l.website, l.website, :class => 'website', :target => 'blank'
-  .clear
+    .clear
   %div.operator_type
     - if (l.operator_id)
       - if ((l.operator.website && l.operator.website.empty?) || (!l.operator.website))
         %li.operator
           %span.italic Operated by:
-          %span.bold #{l.operator.name}
+          %span.bold &nbsp;#{l.operator.name}
         .clear
       - else
         %li.operator
@@ -24,7 +25,7 @@
     - if (l.location_type)
       %li.location_type
         %span.italic Location Type:
-        %span.bold #{l.location_type.name}
+        %span.bold &nbsp;#{l.location_type.name}
   .clear
 %div[l, :metadata_edit]{:style => 'display:none'}
   = form_tag update_metadata_locations_path(:action => 'update_metadata', :id => l.id, :region => @region.name), :id => "update_metadata_#{l.id}", :method => 'get' do

--- a/app/views/locations/_render_update_metadata.html.haml
+++ b/app/views/locations/_render_update_metadata.html.haml
@@ -61,7 +61,7 @@
     return false;
   });
 
-  $('#metadata_cancel_#{l.id}, #metadata_show_location_#{l.id} .location_meta, .location_meta .meta_image').click(function () {
+  $('#metadata_cancel_#{l.id}, #location_detail_location_#{l.id} .location_meta .meta_image').click(function () {
     $('#metadata_show_location_#{l.id}').toggle();
     $('#metadata_edit_location_#{l.id}').toggle();
   });

--- a/spec/features/location_machine_xrefs_controller_spec.rb
+++ b/spec/features/location_machine_xrefs_controller_spec.rb
@@ -731,7 +731,7 @@ describe LocationMachineXrefsController do
       visit "/#{@region.name}"
       page.find('input#location_search_button').click
 
-      page.find("div#desc_show_location_#{@location.id}.desc_show_location").click
+      page.find("#location_detail_location_#{@location.id} .location_description .comment_image").click
       fill_in("new_desc_#{@location.id}", with: 'New Condition')
       click_on("save_desc_#{@location.id}")
 

--- a/spec/features/locations_controller_spec.rb
+++ b/spec/features/locations_controller_spec.rb
@@ -315,7 +315,7 @@ describe LocationsController do
 
       visit '/portland/?by_location_id=' + @location.id.to_s
 
-      find('.location_meta span.meta_image').click
+      find('.location_meta .meta_image').click
       fill_in("new_phone_#{@location.id}", with: '')
       fill_in("new_website_#{@location.id}", with: 'THIS IS SPAM')
       click_on 'Save'
@@ -363,7 +363,7 @@ describe LocationsController do
 
       visit '/portland/?by_location_id=' + @location.id.to_s
 
-      find("#desc_show_location_#{@location.id}").click
+      find("#location_detail_location_#{@location.id} .location_description .comment_image").click
       fill_in("new_desc_#{@location.id}", with: 'THIS IS SPAM')
       click_on 'Save'
 
@@ -375,7 +375,7 @@ describe LocationsController do
     it 'does not allow descs with http://- stubbed out spam detection' do
       visit '/portland/?by_location_id=' + @location.id.to_s
 
-      find("#desc_show_location_#{@location.id}").click
+      find("#location_detail_location_#{@location.id} .location_description .comment_image").click
       fill_in("new_desc_#{@location.id}", with: 'http://hopethisdoesntwork.com foo bar baz')
       click_on 'Save'
 
@@ -387,7 +387,7 @@ describe LocationsController do
     it 'does not allow descs with https://- stubbed out spam detection' do
       visit '/portland/?by_location_id=' + @location.id.to_s
 
-      find("#desc_show_location_#{@location.id}").click
+      find("#location_detail_location_#{@location.id} .location_description .comment_image").click
       fill_in("new_desc_#{@location.id}", with: 'https://hopethisdoesntwork.com foo bar baz')
       click_on 'Save'
 
@@ -399,7 +399,7 @@ describe LocationsController do
     it 'allows users to update a location description - stubbed out spam detection' do
       visit '/portland/?by_location_id=' + @location.id.to_s
 
-      find("#desc_show_location_#{@location.id}").click
+      find("#location_detail_location_#{@location.id} .location_description .comment_image").click
       fill_in("new_desc_#{@location.id}", with: 'COOL DESC')
       click_on 'Save'
 
@@ -411,7 +411,7 @@ describe LocationsController do
     it 'allows users to update a location description - skips validation' do
       visit '/portland/?by_location_id=' + @location.id.to_s
 
-      find("#desc_show_location_#{@location.id}").click
+      find("#location_detail_location_#{@location.id} .location_description .comment_image").click
       fill_in("new_desc_#{@location.id}", with: 'COOL DESC')
       click_on 'Save'
 
@@ -423,7 +423,7 @@ describe LocationsController do
     it 'does not error on nil descriptions' do
       visit '/portland/?by_location_id=' + @location.id.to_s
 
-      find("#desc_show_location_#{@location.id}").click
+      find("#location_detail_location_#{@location.id} .location_description .comment_image").click
       fill_in("new_desc_#{@location.id}", with: nil)
       click_on 'Save'
 
@@ -435,7 +435,7 @@ describe LocationsController do
     it 'updates location last updated' do
       visit '/portland/?by_location_id=' + @location.id.to_s
 
-      find("#desc_show_location_#{@location.id}").click
+      find("#location_detail_location_#{@location.id} .location_description .comment_image").click
       fill_in("new_desc_#{@location.id}", with: 'coooool')
       click_on 'Save'
 
@@ -452,7 +452,7 @@ describe LocationsController do
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus efficitur porta dui vel eleifend. Maecenas pulvinar varius euismod. Curabitur luctus diam quis pulvinar facilisis. Suspendisse eu felis sit amet eros cursus aliquam. Proin sit amet posuere.
 HERE
 
-      find("#desc_show_location_#{@location.id}").click
+      find("#location_detail_location_#{@location.id} .location_description .comment_image").click
       fill_in("new_desc_#{@location.id}", with: string_that_is_too_large)
       click_on 'Save'
 


### PR DESCRIPTION
Not too happy with the tests.

This `find('#location_detail_location_#{@location.id} .location_meta .meta_image').click` produces a fail, while this `find('.location_meta span.meta_image').click` does not. 

But using `#location_detail_location_#{@location.id}` in the selector works fine for descriptions. I don't get why it doesn't work for the meta span. The error is: 
`The browser raised a syntax error while trying to evaluate css selector "#location_detail_location_\#{@location.id} .location_meta .meta_image"`

