### PR TITLE
mobile style adjustment for region intro text

### DIFF
--- a/app/assets/stylesheets/mobile-application.css.erb
+++ b/app/assets/stylesheets/mobile-application.css.erb
@@ -352,7 +352,7 @@ div.pick_a_map {
   margin: 0 10px;
 }
 #locations p {
-  margin-top: 0;
+  margin: 0px 15px 15px;
 }
 
 .home_intro {
@@ -365,7 +365,7 @@ div.pick_a_map {
 }
 
 #intro {
-  padding: 10px;
+  padding: 0 10px 10px;
   max-width: 100%;
 }
 
@@ -375,7 +375,7 @@ div.pick_a_map {
 }
 
 #intro p {
-  margin-top: 0;
+  margin: 0;
 }
 
 .local_logo img {


### PR DESCRIPTION
barely had to change anything. This map-loading looks good on mobile, because previously the intro text used the map div, and I had to size that map div for the map and not for the text. So there was empty space below the text, because the div was too tall.