### PR TITLE
moved alert for disabled users to devise locale; updated the confirm message

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,10 +49,6 @@ class User < ActiveRecord::Base
     super && !self.is_disabled?
   end
 
-  def inactive_message
-    'Your account is not active. Please contact our support team if you think this was a mistake.'
-  end
-
   def name
     username
   end

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,4 +1,4 @@
-<p>Welcome to Pinball Map, <%= @username %>!</p>
+<p>Welcome to Pinball Map, <%= @resource.username %>!</p>
 
 <p>You can confirm your account email through the link below:</p>
 

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -13,7 +13,7 @@ en:
       invalid: 'Invalid email or password.'
       invalid_token: 'Invalid authentication token.'
       timeout: 'Your session expired, please login again to continue.'
-      inactive: 'Your account was not activated yet.'
+      inactive: 'Your account is disabled. Please contact us if you think this is a mistake.'
     sessions:
       signed_in: 'Signed in successfully.'
       signed_out: 'Signed out successfully.'
@@ -27,6 +27,7 @@ en:
       signed_up: 'You have signed up successfully. If enabled, a confirmation was sent to your e-mail.'
       updated: 'You updated your account successfully.'
       destroyed: 'Bye! Your account was successfully cancelled. We hope to see you again soon.'
+      signed_up_but_unconfirmed: "Great! Now confirm your account. A confirmation link has been sent to your email address."
     unlocks:
       send_instructions: 'You will receive an email with instructions about how to unlock your account in a few minutes.'
       unlocked: 'Your account was successfully unlocked.'


### PR DESCRIPTION
I think this is fine. I removed the "inactive" message that you added in this commit https://github.com/scottwainstock/pbm/commit/1474eb237dbb530bf041c8d53104a01bb8eda0fd
and moved it to here https://github.com/RyanTG/pbm/commit/33466072830c9c2fcfd88cdf3383c78bec7d8a9e#diff-f3d6e5d1f2709fef60571f46916a5f23

If I disable an account, and then try to log in with the account, I see that message. So it seems like it's working. 