### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Below is a summary of the steps that [Brian Hanifin](https://github.com/brianhan
 * `cd /Projects-Path/`
 * `git clone https://github.com/scottwainstock/pbm.git` (*I used the SourceTree app instead.*)
 * `cd /Projects-Path/pbm`
-* `rvm --default use ruby-1.9.3`
+* `rvm --default use ruby-2.1.2`
 * `bundle install`
 * `selenium install`
 * `brew update && brew install phantomjs`

--- a/README.md
+++ b/README.md
@@ -56,5 +56,6 @@ cucumber:
 * `curl get.pow.cx | sh`
 * `cd ~/.pow`
 * `ln -s /Projects-Path/pbm`
+* `open http://pbm.dev`
 
 If the site loads properly it will be an empty version of pinballmap.com, then ask Scott for a data dump so you can have a full set of data to work with.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Available here: [http://pinballmap.com/api/v1/docs](http://pinballmap.com/api/v1
 ##Mac Enviroment Setup
 Below is a summary of the steps that [Brian Hanifin](https://github.com/brianhanifin) undertook to get the site up and running on OS X 10.9. If you would like to contribute, and have any trouble, please ask.
 
-* Follow the Ruby install instructions at [railsapps.github.io/installrubyonrails-mac.html](http://railsapps.github.io/installrubyonrails-mac.html). Make sure you also download ruby-1.9.3.
+* Follow the Ruby install instructions at [railsapps.github.io/installrubyonrails-mac.html](http://railsapps.github.io/installrubyonrails-mac.html). Make sure you also download ruby-2.1.2.
 * `cd /Projects-Path/`
 * `git clone https://github.com/scottwainstock/pbm.git` (*I used the SourceTree app instead.*)
 * `cd /Projects-Path/pbm`
@@ -47,7 +47,7 @@ cucumber:
 ```
 
 * `brew install postgresql`
-* `initdb /usr/local/var/postres -E utf8`
+* `initdb /usr/local/var/postgres -E utf8`
 * Download [Postgres App](http://postgresapp.com/). (*I have mine run at startup on my "Dev" profile.*)
 * `bundle exec rake db:create ; RAILS_ENV=test bundle exec rake db:create`
 * `bundle exec rake db:migrate ; RAILS_ENV=test bundle exec rake db:migrate`
@@ -56,7 +56,5 @@ cucumber:
 * `curl get.pow.cx | sh`
 * `cd ~/.pow`
 * `ln -s /Projects-Path/pbm`
-* Edit config.ru: change `run Pbm::Application` to `self.run Pbm::Application` (Workaround: so Pow can run the site.)
-* `open http://pbm.dev`
 
 If the site loads properly it will be an empty version of pinballmap.com, then ask Scott for a data dump so you can have a full set of data to work with.


### PR DESCRIPTION
I just got the PBM running locally on my machine- it appears some of the instructions in the README are outdated. The README specifies using Ruby 1.9.3, but the gemfile specifies Ruby 2.1.2- I had to end up using 2.1.2 on my end to get things to work without changing any files in the repo. Additionally, the config.ru file already has the code changed to what is indicated that one should manually change.