### PR TITLE
Additional fields for submit location form

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -2358,6 +2358,7 @@ div.map_summary_info {
   min-width: 575px;
   max-height: 200px;
   margin: 0;
+  font-size: 14px;
 }
 
 #location_maker textarea.comments {
@@ -2367,6 +2368,7 @@ div.map_summary_info {
   min-width: 575px;
   max-height: 200px;
   margin: 0;
+  font-size: 14px;
 }
 
 #location_maker li.machines, #location_maker li.recaptcha,

--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -2359,6 +2359,16 @@ div.map_summary_info {
   max-height: 200px;
   margin: 0;
 }
+
+#location_maker textarea.comments {
+  height: 28px;
+  width: 575px;
+  max-width: 575px;
+  min-width: 575px;
+  max-height: 200px;
+  margin: 0;
+}
+
 #location_maker li.machines, #location_maker li.recaptcha,
 #contact_maker li.recaptcha, #contact_maker li.msg {
   height: auto;

--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -2351,7 +2351,7 @@ div.map_summary_info {
   height: 100px;
   max-height: 150px;
 }
-#location_maker textarea.machines {
+#location_maker textarea.comments {
   height: 50px;
   width: 575px;
   max-width: 575px;
@@ -2360,14 +2360,13 @@ div.map_summary_info {
   margin: 0;
   font-size: 14px;
 }
-
-#location_maker textarea.comments {
-  height: 28px;
+#location_maker textarea.machines {
+  height: 50px;
   width: 575px;
   max-width: 575px;
   min-width: 575px;
   max-height: 200px;
-  margin: 0;
+  margin-bottom: 250px;
   font-size: 14px;
 }
 

--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -2351,22 +2351,13 @@ div.map_summary_info {
   height: 100px;
   max-height: 150px;
 }
-#location_maker textarea.comments {
+#location_maker textarea.comments, #location_maker textarea.machines {
   height: 50px;
   width: 575px;
   max-width: 575px;
   min-width: 575px;
   max-height: 200px;
   margin: 0;
-  font-size: 14px;
-}
-#location_maker textarea.machines {
-  height: 50px;
-  width: 575px;
-  max-width: 575px;
-  min-width: 575px;
-  max-height: 200px;
-  margin-bottom: 250px;
   font-size: 14px;
 }
 

--- a/app/controllers/api/v1/locations_controller.rb
+++ b/app/controllers/api/v1/locations_controller.rb
@@ -18,7 +18,9 @@ module Api
       param :location_zip, String, desc: 'Zip code of new location', required: false
       param :location_phone, String, desc: 'Phone number of new location', required: false
       param :location_website, String, desc: 'Website of new location', required: false
+      param :location_type, String, desc: 'Type of location', required: false
       param :location_operator, String, desc: 'Machine operator of new location', required: false
+      param :location_comments, String, desc: 'Comments', required: false
       param :location_machines, String, desc: 'List of machines at new location', required: true
       formats ['json']
       def suggest

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,7 +53,9 @@ State: #{params['location_state']}\n
 Zip: #{params['location_zip']}\n
 Phone: #{params['location_phone']}\n
 Website: #{params['location_website']}\n
+Type: #{params['location_type']}\n
 Operator: #{params['location_operator']}\n
+Comments: #{params['location_comments']}\n
 Machines: #{params['location_machines']}\n
 (entered from #{request.remote_ip} via #{request.user_agent}#{user_info})\n
 END

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -103,7 +103,7 @@ class PagesController < ApplicationController
 
   def suggest_new_location
     @states = Location.where(['region_id = ?', @region.id]).map(&:state).uniq.sort
-    @location_types = LocationType.all().map(&:name).uniq.sort
+    @location_types = LocationType.all.map(&:name).uniq.sort
   end
 
   def robots

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -103,6 +103,7 @@ class PagesController < ApplicationController
 
   def suggest_new_location
     @states = Location.where(['region_id = ?', @region.id]).map(&:state).uniq.sort
+    @location_types = LocationType.all().map(&:name).uniq.sort
   end
 
   def robots

--- a/app/views/pages/suggest_new_location.html.haml
+++ b/app/views/pages/suggest_new_location.html.haml
@@ -30,13 +30,7 @@
                 %input{:type => "text", :name => "location_website", :params => "location_website", :class => "text"}
               %li
                 %label{:for => "location_type"} Location Type:
-                %select
-                  %option{value: "Bar", :selected => params[:x] == "Bar"}= "Bar"
-                  %option{value: "Bar/Restaurant", :selected => params[:x] == "Bar/Restaurant"}= "Bar/Restaurant"
-                  %option{value: "Bowling Alley", :selected => params[:x] == "Bowling Alley"}= "Bowling Alley"
-                  %option{value: "Pizza Parlor", :selected => params[:x] == "Pizza Parlor"}= "Pizza Parlor"
-                  %option{value: "Restaurant", :selected => params[:x] == "Restaurant"}= "Restaurant"
-                  %option{value: "Roller Skating Rink", :selected => params[:x] == "Roller Skating Rink"}= "Roller Skating Rink"
+                = select_tag :name, options_for_select(@location_types, default = "Bar")
               %li
                 %label{:for => "location_operator"} Operator:
                 %input{:type => "text", :name => "location_operator", :params => "location_operator", :class => "text"}

--- a/app/views/pages/suggest_new_location.html.haml
+++ b/app/views/pages/suggest_new_location.html.haml
@@ -37,7 +37,6 @@
                   %option{value: "Pizza Parlor", :selected => params[:x] == "Pizza Parlor"}= "Pizza Parlor"
                   %option{value: "Restaurant", :selected => params[:x] == "Restaurant"}= "Restaurant"
                   %option{value: "Roller Skating Rink", :selected => params[:x] == "Roller Skating Rink"}= "Roller Skating Rink"
-
               %li
                 %label{:for => "location_operator"} Operator:
                 %input{:type => "text", :name => "location_operator", :params => "location_operator", :class => "text"}

--- a/app/views/pages/suggest_new_location.html.haml
+++ b/app/views/pages/suggest_new_location.html.haml
@@ -37,9 +37,11 @@
               %li
                 %label{:for => "location_comments"} Comments:
                 %textarea{:type => "text", :name => "location_comments", :params => "location_comments", :class => "text comments"}
-              %li.machines{:class => "first"}
+              %br
+              %li
                 %label{:for => "location_machines"} Machines:
                 %textarea{:type => "text", :name => "location_machines", :params => "location_machines", :class => "text machines"}
+              %br
               %li.submit{:style => "clear:both;"}
                 %input{:type => "submit", :value => "Submit New Location", :class => "submit_button"}
 

--- a/app/views/pages/suggest_new_location.html.haml
+++ b/app/views/pages/suggest_new_location.html.haml
@@ -30,7 +30,7 @@
                 %input{:type => "text", :name => "location_website", :params => "location_website", :class => "text"}
               %li
                 %label{:for => "location_type"} Location Type:
-                = select_tag :name, options_for_select(@location_types, default = "Bar")
+                = select_tag :location_type, options_for_select(@location_types, default = "Bar")
               %li
                 %label{:for => "location_operator"} Operator:
                 %input{:type => "text", :name => "location_operator", :params => "location_operator", :class => "text"}

--- a/app/views/pages/suggest_new_location.html.haml
+++ b/app/views/pages/suggest_new_location.html.haml
@@ -29,8 +29,21 @@
                 %label{:for => "location_website"} Website:
                 %input{:type => "text", :name => "location_website", :params => "location_website", :class => "text"}
               %li
+                %label{:for => "location_type"} Location Type:
+                %select
+                  %option{value: "Bar", :selected => params[:x] == "Bar"}= "Bar"
+                  %option{value: "Bar/Restaurant", :selected => params[:x] == "Bar/Restaurant"}= "Bar/Restaurant"
+                  %option{value: "Bowling Alley", :selected => params[:x] == "Bowling Alley"}= "Bowling Alley"
+                  %option{value: "Pizza Parlor", :selected => params[:x] == "Pizza Parlor"}= "Pizza Parlor"
+                  %option{value: "Restaurant", :selected => params[:x] == "Restaurant"}= "Restaurant"
+                  %option{value: "Roller Skating Rink", :selected => params[:x] == "Roller Skating Rink"}= "Roller Skating Rink"
+
+              %li
                 %label{:for => "location_operator"} Operator:
                 %input{:type => "text", :name => "location_operator", :params => "location_operator", :class => "text"}
+              %li
+                %label{:for => "location_comments"} Comments:
+                %textarea{:type => "text", :name => "location_comments", :params => "location_comments", :class => "text comments"}
               %li.machines{:class => "first"}
                 %label{:for => "location_machines"} Machines:
                 %textarea{:type => "text", :name => "location_machines", :params => "location_machines", :class => "text machines"}

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -151,7 +151,9 @@ State: state\n
 Zip: zip\n
 Phone: phone\n
 Website: website\n
+Type: type\n
 Operator: operator\n
+Comments: comments\n
 Machines: machines\n
 (entered from 0.0.0.0 via Rails Testing)\n
 HERE
@@ -166,7 +168,7 @@ HERE
         )
       end
 
-      post 'submitted_new_location', region: 'portland', location_name: 'name', location_street: 'street', location_city: 'city', location_state: 'state', location_zip: 'zip', location_phone: 'phone', location_website: 'website', location_operator: 'operator', location_machines: 'machines', submitter_name: 'subname', submitter_email: 'subemail'
+      post 'submitted_new_location', region: 'portland', location_name: 'name', location_street: 'street', location_city: 'city', location_state: 'state', location_zip: 'zip', location_phone: 'phone', location_website: 'website', location_type: 'type', location_operator: 'operator', location_comments: 'comments', location_machines: 'machines', submitter_name: 'subname', submitter_email: 'subemail'
 
       expect(@region.user_submissions.count).to eq(1)
       submission = @region.user_submissions.first
@@ -186,7 +188,9 @@ State: state\n
 Zip: zip\n
 Phone: phone\n
 Website: website\n
+Type: type\n
 Operator: operator\n
+Comments: comments\n
 Machines: machines\n
 (entered from 0.0.0.0 via Rails Testing by ssw (yeah@ok.com))\n
 HERE
@@ -200,7 +204,7 @@ HERE
         )
       end
 
-      post 'submitted_new_location', region: 'portland', location_name: 'name', location_street: 'street', location_city: 'city', location_state: 'state', location_zip: 'zip', location_phone: 'phone', location_website: 'website', location_operator: 'operator', location_machines: 'machines', submitter_name: 'subname', submitter_email: 'subemail'
+      post 'submitted_new_location', region: 'portland', location_name: 'name', location_street: 'street', location_city: 'city', location_state: 'state', location_zip: 'zip', location_phone: 'phone', location_website: 'website', location_type: 'type', location_operator: 'operator', location_comments: 'comments', location_machines: 'machines', submitter_name: 'subname', submitter_email: 'subemail'
     end
 
     it 'should send an email - notifies if sent from the staging server' do
@@ -212,7 +216,7 @@ HERE
         )
       end
 
-      post 'submitted_new_location', region: 'portland', location_name: 'name', location_street: 'street', location_city: 'city', location_state: 'state', location_zip: 'zip', location_phone: 'phone', location_website: 'website', location_operator: 'operator', location_machines: 'machines', submitter_name: 'subname', submitter_email: 'subemail'
+      post 'submitted_new_location', region: 'portland', location_name: 'name', location_street: 'street', location_city: 'city', location_state: 'state', location_zip: 'zip', location_phone: 'phone', location_website: 'website', location_type: 'type', location_operator: 'operator', location_comments: 'comments', location_machines: 'machines', submitter_name: 'subname', submitter_email: 'subemail'
     end
   end
 end

--- a/spec/requests/api/v1/locations_controller_spec.rb
+++ b/spec/requests/api/v1/locations_controller_spec.rb
@@ -54,14 +54,16 @@ State: state\n
 Zip: zip\n
 Phone: phone\n
 Website: website\n
+Type: type\n
 Operator: operator\n
+Comments: comments\n
 Machines: machines\n
 (entered from 127.0.0.1 via cleOS)\n
 HERE
         )
       end
 
-      post '/api/v1/locations/suggest.json', { region_id: @region.id.to_s, location_name: 'name', location_street: 'street', location_city: 'city', location_state: 'state', location_zip: 'zip', location_phone: 'phone', location_website: 'website', location_operator: 'operator', location_machines: 'machines', submitter_name: 'subname', submitter_email: 'subemail' }, HTTP_USER_AGENT: 'cleOS'
+      post '/api/v1/locations/suggest.json', { region_id: @region.id.to_s, location_name: 'name', location_street: 'street', location_city: 'city', location_state: 'state', location_zip: 'zip', location_phone: 'phone', location_website: 'website', location_type: 'type', location_operator: 'operator', location_comments: 'comments', location_machines: 'machines', submitter_name: 'subname', submitter_email: 'subemail' }, HTTP_USER_AGENT: 'cleOS'
       expect(response).to be_success
 
       expect(JSON.parse(response.body)['msg']).to eq("Thanks for entering that location. We'll get it in the system as soon as possible.")
@@ -70,7 +72,7 @@ HERE
     end
 
     it 'tags a user when appropriate' do
-      post '/api/v1/locations/suggest.json', { region_id: @region.id.to_s, location_name: 'name', location_street: 'street', location_city: 'city', location_state: 'state', location_zip: 'zip', location_phone: 'phone', location_website: 'website', location_operator: 'operator', location_machines: 'machines', submitter_name: 'subname', submitter_email: 'subemail', user_email: 'foo@bar.com', user_token: '1G8_s7P-V-4MGojaKD7a' }, HTTP_USER_AGENT: 'cleOS'
+      post '/api/v1/locations/suggest.json', { region_id: @region.id.to_s, location_name: 'name', location_street: 'street', location_city: 'city', location_state: 'state', location_zip: 'zip', location_phone: 'phone', location_website: 'website', location_type: 'type', location_operator: 'operator', location_comments: 'comments', location_machines: 'machines', submitter_name: 'subname', submitter_email: 'subemail', user_email: 'foo@bar.com', user_token: '1G8_s7P-V-4MGojaKD7a' }, HTTP_USER_AGENT: 'cleOS'
 
       expect(response).to be_success
       expect(UserSubmission.first.user_id).to eq(111)


### PR DESCRIPTION
Added fields to submit location form and associated tests. Confirmed fields from form are populating in the user_submissions table. Pulled location_types from db model... set default to "Bar" rather than the alphabetical selection of "Adult Shop" :) 

With regard to the form appearance itself, had to use breaks to get the textareas to format nicely. I'm sure there's likely a more elegant way?

Thank you for the help and patience as I've been getting to know this project!