### PR TITLE
doubled the amount of rack requests

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -16,7 +16,7 @@ if Rails.env.production?
     end
 
     (1..5).each do |level|
-      Rack::Attack.throttle('req/ip/#{level}', :limit => (20 * level), :period => (8 ** level).seconds) do |req|
+      Rack::Attack.throttle('req/ip/#{level}', :limit => (40 * level), :period => (8 ** level).seconds) do |req|
         req.ip
       end
     end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -15,7 +15,7 @@ if Rails.env.production?
       req.user_agent == 'SemrushBot'
     end
 
-    Rack::Attack.throttle('req/ip', :limit => 100, :period => 10.second) do |req|
+    Rack::Attack.throttle('req/ip', :limit => 100, :period => 10.seconds) do |req|
       req.ip
     end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -15,9 +15,7 @@ if Rails.env.production?
       req.user_agent == 'SemrushBot'
     end
 
-    (1..5).each do |level|
-      Rack::Attack.throttle('req/ip/#{level}', :limit => (40 * level), :period => (8 ** level).seconds) do |req|
-        req.ip
-      end
+    Rack::Attack.throttle('req/ip', :limit => 100, :period => 10.second) do |req|
+      req.ip
     end
 end


### PR DESCRIPTION
This is hard to estimate, given that I don't know how many requests occur when, say, adding a machine to a location.

But I added two, and got blocked on the third one! And I'm still blocked, minutes later. At least we know it works.