### PR TITLE
allow admin to manually geocode location edits

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -102,6 +102,7 @@ Their Name: #{params['name']}\n
 Their Email: #{params['email']}\n
 Region Name: #{params['region_name']}\n
 Region Comments: #{params['comments']}\n
+(entered from #{request.remote_ip} via #{request.user_agent})\n
 END
     )
   end
@@ -113,7 +114,8 @@ END
 Their Name: #{params[:name]}\n
 Their Email: #{params[:email]}\n
 Message: #{params[:message]}\n
-#{user_info}
+#{user_info}\n
+(entered from #{request.remote_ip} via #{request.user_agent})\n
 END
     Pony.mail(
       to: region.users.map(&:email),

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -20,7 +20,7 @@ class Location < ActiveRecord::Base
   has_many :machines, through: :location_machine_xrefs
 
   geocoded_by :full_street_address, latitude: :lat, longitude: :lon
-  before_validation :geocode, unless: :should_skip_geocode
+  before_validation :geocode, unless: ENV['SKIP_GEOCODE'] || (:lat && :lon)
 
   MAP_SCALE = 0.75
 

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -77,7 +77,7 @@ HERE
           bcc: ['super_admin@bar.com'],
           from: 'admin@pinballmap.com',
           subject: 'PBM - Message from the Portland region',
-          body: "Their Name: foo\n\nTheir Email: bar\n\nMessage: baz\n\n\n"
+          body: "Their Name: foo\n\nTheir Email: bar\n\nMessage: baz\n\n\n\n(entered from 0.0.0.0 via Rails Testing)\n\n"
         )
       end
 
@@ -85,7 +85,7 @@ HERE
       expect(@region.reload.user_submissions.count).to eq(1)
       submission = @region.user_submissions.first
       expect(submission.submission_type).to eq(UserSubmission::CONTACT_US_TYPE)
-      expect(submission.submission).to eq("Their Name: foo\n\nTheir Email: bar\n\nMessage: baz\n\n\n")
+      expect(submission.submission).to eq("Their Name: foo\n\nTheir Email: bar\n\nMessage: baz\n\n\n\n(entered from 0.0.0.0 via Rails Testing)\n\n")
     end
 
     it 'should include user info if you are logged in' do
@@ -98,14 +98,14 @@ HERE
           bcc: ['super_admin@bar.com'],
           from: 'admin@pinballmap.com',
           subject: 'PBM - Message from the Portland region',
-          body: "Their Name: foo\n\nTheir Email: bar\n\nMessage: baz\n\nUsername: ssw\n\nSite Email: yeah@ok.com\n"
+          body: "Their Name: foo\n\nTheir Email: bar\n\nMessage: baz\n\nUsername: ssw\n\nSite Email: yeah@ok.com\n\n(entered from 0.0.0.0 via Rails Testing)\n\n"
         )
       end
 
       post 'contact_sent', region: 'portland', contact_name: 'foo', contact_email: 'bar', contact_msg: 'baz'
       submission = @region.reload.user_submissions.first
       expect(submission.user).to eq(user)
-      expect(submission.submission).to eq("Their Name: foo\n\nTheir Email: bar\n\nMessage: baz\n\nUsername: ssw\n\nSite Email: yeah@ok.com\n")
+      expect(submission.submission).to eq("Their Name: foo\n\nTheir Email: bar\n\nMessage: baz\n\nUsername: ssw\n\nSite Email: yeah@ok.com\n\n(entered from 0.0.0.0 via Rails Testing)\n\n")
     end
 
     it 'email should notify if it was sent from the staging server' do

--- a/spec/requests/api/v1/regions_controller_spec.rb
+++ b/spec/requests/api/v1/regions_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Api::V1::RegionsController, type: :request do
-
   before(:each) do
     @portland = FactoryGirl.create(:region, id: 555, name: 'portland', motd: 'foo', full_name: 'Portland', lat: 12, lon: 13)
     @la = FactoryGirl.create(:region, name: 'la', full_name: 'Los Angeles')

--- a/spec/requests/api/v1/regions_controller_spec.rb
+++ b/spec/requests/api/v1/regions_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe Api::V1::RegionsController, type: :request do
+
   before(:each) do
     @portland = FactoryGirl.create(:region, id: 555, name: 'portland', motd: 'foo', full_name: 'Portland', lat: 12, lon: 13)
     @la = FactoryGirl.create(:region, name: 'la', full_name: 'Los Angeles')
@@ -135,11 +136,12 @@ Their Name: ssw\n
 Their Email: foo@bar.com\n
 Region Name: region name\n
 Region Comments: region comments\n
+(entered from 127.0.0.1 via cleOS)\n
 HERE
         )
       end
 
-      post '/api/v1/regions/suggest.json', region_name: 'region name', comments: 'region comments', user_email: 'foo@bar.com', user_token: '1G8_s7P-V-4MGojaKD7a'
+      post '/api/v1/regions/suggest.json', { region_name: 'region name', comments: 'region comments', user_email: 'foo@bar.com', user_token: '1G8_s7P-V-4MGojaKD7a' }, HTTP_USER_AGENT: 'cleOS'
       expect(response).to be_success
 
       expect(JSON.parse(response.body)['msg']).to eq("Thanks for suggesting that region. We'll be in touch.")
@@ -183,12 +185,13 @@ Their Name: name\n
 Their Email: email\n
 Message: message\n
 Username: ssw\n
-Site Email: foo@bar.com
+Site Email: foo@bar.com\n
+(entered from 127.0.0.1 via cleOS)\n
 HERE
         )
       end
 
-      post '/api/v1/regions/contact.json', region_id: @la.id.to_s, email: 'email', message: 'message', name: 'name', user_email: 'foo@bar.com', user_token: '1G8_s7P-V-4MGojaKD7a'
+      post '/api/v1/regions/contact.json', { region_id: @la.id.to_s, email: 'email', message: 'message', name: 'name', user_email: 'foo@bar.com', user_token: '1G8_s7P-V-4MGojaKD7a' }, HTTP_USER_AGENT: 'cleOS'
       expect(response).to be_success
 
       expect(JSON.parse(response.body)['msg']).to eq('Thanks for the message.')
@@ -208,12 +211,13 @@ Their Name: name\n
 Their Email: email\n
 Message: message\n
 Username: ssw\n
-Site Email: foo@bar.com
+Site Email: foo@bar.com\n
+(entered from 127.0.0.1 via cleOS)\n
 HERE
         )
       end
 
-      post '/api/v1/regions/contact.json', region_id: @la.id.to_s, email: 'email', message: 'message', name: 'name', user_email: 'foo@bar.com', user_token: '1G8_s7P-V-4MGojaKD7a'
+      post '/api/v1/regions/contact.json', { region_id: @la.id.to_s, email: 'email', message: 'message', name: 'name', user_email: 'foo@bar.com', user_token: '1G8_s7P-V-4MGojaKD7a' }, HTTP_USER_AGENT: 'cleOS'
       expect(response).to be_success
 
       expect(JSON.parse(response.body)['msg']).to eq('Thanks for the message.')


### PR DESCRIPTION
Basically reverting one of the commits from last week. Though I didn't remove the def for it. Not sure if that's bad practice.