### PR TITLE
removed some parentheses from daily digests

### DIFF
--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -138,7 +138,7 @@ class Region < ActiveRecord::Base
     return nil if submissions.nil? || submissions.empty?
 
     <<HERE
-Here's a list of all the comments that were placed in your region on #{(DateTime.now - 1.day).strftime('%m/%d/%Y')}. Questions/concerns? Contact pinballmap@posteo.org
+Here is a list of all the comments that were placed in your region on #{(DateTime.now - 1.day).strftime('%m/%d/%Y')}. Questions/concerns? Contact pinballmap@posteo.org
 
 #{full_name} Daily Comments
 
@@ -155,7 +155,7 @@ HERE
     return nil if submissions.nil? || submissions.empty?
 
     <<HERE
-Here's a list of all the machines that were removed from your region on #{(DateTime.now - 1.day).strftime('%m/%d/%Y')}. Questions/concerns? Contact pinballmap@posteo.org
+Here is a list of all the machines that were removed from your region on #{(DateTime.now - 1.day).strftime('%m/%d/%Y')}. Questions/concerns? Contact pinballmap@posteo.org
 
 #{full_name} Daily Machine Removals
 
@@ -168,7 +168,7 @@ HERE
     end_of_week = DateTime.now.end_of_day
 
     <<HERE
-Here's an overview of your pinball map region! Thanks for keeping your region updated! Please remove any empty locations and add any submitted ones. Questions/concerns? Contact pinballmap@posteo.org
+Here is an overview of your pinball map region! Thanks for keeping your region updated! Please remove any empty locations and add any submitted ones. Questions/concerns? Contact pinballmap@posteo.org
 
 #{full_name} Weekly Overview
 

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -44,7 +44,7 @@ describe Region do
       FactoryGirl.create(:user_submission, region: @region, submission: 'baz', submission_type: UserSubmission::REMOVE_MACHINE_TYPE)
 
       expect(@region.generate_daily_digest_comments_email_body).to eq(<<HERE)
-Here's a list of all the comments that were placed in your region on #{(DateTime.now - 1.day).strftime('%m/%d/%Y')}. Questions/concerns? Contact pinballmap@posteo.org
+Here is a list of all the comments that were placed in your region on #{(DateTime.now - 1.day).strftime('%m/%d/%Y')}. Questions/concerns? Contact pinballmap@posteo.org
 
 Portland Daily Comments
 
@@ -71,7 +71,7 @@ HERE
       FactoryGirl.create(:user_submission, region: @region, submission: 'baz', submission_type: UserSubmission::NEW_CONDITION_TYPE)
 
       expect(@region.generate_daily_digest_removals_email_body).to eq(<<HERE)
-Here's a list of all the machines that were removed from your region on #{(DateTime.now - 1.day).strftime('%m/%d/%Y')}. Questions/concerns? Contact pinballmap@posteo.org
+Here is a list of all the machines that were removed from your region on #{(DateTime.now - 1.day).strftime('%m/%d/%Y')}. Questions/concerns? Contact pinballmap@posteo.org
 
 Portland Daily Machine Removals
 
@@ -114,7 +114,7 @@ HERE
       FactoryGirl.create(:user_submission, region: @region, submission_type: 'contact_us')
 
       expect(@region.generate_weekly_admin_email_body).to eq(<<HERE)
-Here's an overview of your pinball map region! Thanks for keeping your region updated! Please remove any empty locations and add any submitted ones. Questions/concerns? Contact pinballmap@posteo.org
+Here is an overview of your pinball map region! Thanks for keeping your region updated! Please remove any empty locations and add any submitted ones. Questions/concerns? Contact pinballmap@posteo.org
 
 Portland Weekly Overview
 


### PR DESCRIPTION
Perhaps this will fix the Weekly Digests. I noticed that the syntax on https://github.com/scottwainstock/pbm/blob/97fd5a7407139137dcf5881db6d37e75d7dde7e0/app/models/region.rb was displaying weirdly right after it said "Here's" which perhaps was breaking the Weekly Digest stuff below it. So I changed those to "Here is".