### PR TITLE
Added button to minimize lookup

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -863,6 +863,7 @@ span.or {
 #form {
   position: fixed;
   top: 52px;
+  margin-left: 0;
   width: 640px;
   box-sizing: border-box;
   -moz-box-sizing: border-box;
@@ -892,6 +893,7 @@ span.or {
   float: left;
   padding: 75px 10px 10px 10px;
   width: 640px;
+  background: #FFFFFF;
   box-sizing: border-box;
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
@@ -908,9 +910,8 @@ span.or {
 .hide_search_link, .hide_button {
   display: none;
 }
-#mapFollow_wrapper, #search_link_wrapper {
+#mapFollow_wrapper, #search_link_wrapper, #min_lookup_wrapper {
   position: fixed;
-  left: 650px;
   top: 60px;
   width: 100px;
   border: 3px solid #D3ECFF;
@@ -923,19 +924,8 @@ span.or {
   font-size: 15px;
 }
 #search_link_wrapper {
-  top: 130px;
-}
-#mapFollow_wrapper input {
-  margin: 0;
-}
-.redo_gone {
-  height: 0 !important;
-  padding-bottom: 0 !important;
-  padding-top: 0 !important;
-  margin-bottom: 0 !important;
-}
-#search_link_wrapper {
   padding-top: 5px;
+  top: 170px;
 }
 #search_link_wrapper a {
   color: #303030;
@@ -944,6 +934,48 @@ span.or {
 }
 #search_link_wrapper a:hover  {
   text-decoration: underline;
+}
+#mapFollow_wrapper {
+  top: 100px;
+}
+#mapFollow_wrapper input {
+  margin: 0;
+}
+.toggle_min_lookup, .toggle_reg_lookup, .toggle_btn_reg, .toggle_map_btn {
+  -webkit-transition: all 0.5s ease-in-out;
+  -moz-transition:all 0.5s ease-in-out;
+  -o-transition:all 0.5s ease-in-out;
+  transition:all 0.5s ease-in-out;
+}
+.toggle_min_lookup {
+  margin-left: -580px !important;
+}
+.toggle_reg_lookup {
+  margin-left: 0px !important;
+}
+.toggle_btn_reg {
+  left: 650px !important;
+}
+.toggle_map_btn {
+  left: 60px !important;
+}
+.slide_left:before {
+  content: "<  more map";
+  width: 30px;
+  height: 20px;
+  position: relative;
+}
+.slide_right:before {
+  content: ">  less map";
+  width: 30px;
+  height: 20px;
+  position: relative;
+}
+.redo_gone {
+  height: 0 !important;
+  padding-bottom: 0 !important;
+  padding-top: 0 !important;
+  margin-bottom: 0 !important;
 }
 .location_link {
   font-size: 18px;
@@ -2233,18 +2265,15 @@ span.begin {
   box-sizing: border-box;
 }
 #map {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  margin-top: -12px;
   position: fixed;
-  bottom: 0;
-  top: 0;
-  margin-top: 52px;
-  left: 640px;
-  right: 0;
-  min-width: 296px;
-  height: auto;
 }
 #map_canvas {
+  margin-right: -640px;
   height: 100% !important;
-  width: 100% !important;
 }
 #intro {
   padding: 5px 20px;
@@ -2535,6 +2564,53 @@ div.score_list {
 }
 #region_map .gm_region_name a:hover {
   color: #58266F;
+}
+/* // Maps logo and controls
+// https://www.google.com/permissions/geoguidelines/attr-guide.html
+// https://web.archive.org/web/20160505030052/http://www.google.com/permissions/geoguidelines/attr-guide.html
+// The automatically generated Google logo and data provider attribution may only be removed or obstructed if reintroduced in a visible form elsewhere within the Content (e.g. photo caption below a Google Earth still). In other words, your text must be as visible as it would have been if you had used the default text that we provide.
+// .gm-style:first-child is standard map view
+//  1 : map
+//  2 : google logo
+//  3 : map-data window
+//  4 : map data
+//  5 : map data (noscreen)
+//  6 : terms of use
+//  7 : full screen
+//  8 : report map error
+//  9 : map controls
+// 10 : map type controls */
+
+.gm-style div:first-child,
+.gm-style div:nth-child(3),
+.gm-style div:nth-child(9),
+.gm-style div:nth-child(10) {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+.gm-style div:nth-child(7),
+.gm-style  div:nth-child(9) {
+  margin-right: 650px !important;
+}
+.gm-style  div:nth-child(9) {
+  margin-right: 650px !important;
+  margin-bottom: 55px !important;
+}
+.gm-style div:nth-child(10) {
+  margin-left: 650px !important;
+  margin-bottom: 50px !important;
+}
+ .gm-style div:nth-child(4) {
+  right: 795px !important;
+  bottom: 53px !important;
+} 
+.gm-style div:nth-child(6) {
+  right: 730px !important;
+  bottom: 53px !important;
+}
+.gm-style div:nth-child(8) {
+  right: 640px !important;
+  bottom: 53px !important;
 }
 
 /** Rails Admin **/

--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -948,7 +948,7 @@ span.or {
   transition:all 0.5s ease-in-out;
 }
 .toggle_min_lookup {
-  margin-left: -580px !important;
+  margin-left: -640px !important;
 }
 .toggle_reg_lookup {
   margin-left: 0px !important;
@@ -957,16 +957,16 @@ span.or {
   left: 650px !important;
 }
 .toggle_map_btn {
-  left: 60px !important;
+  left: 0px !important;
 }
 .slide_left:before {
-  content: "<  more map";
+  content: "◀  more map";
   width: 30px;
   height: 20px;
   position: relative;
 }
 .slide_right:before {
-  content: ">  less map";
+  content: "▶  less map";
   width: 30px;
   height: 20px;
   position: relative;

--- a/app/assets/stylesheets/mediaqueries.css
+++ b/app/assets/stylesheets/mediaqueries.css
@@ -46,6 +46,9 @@
     .toggle_btn_reg {
       left: 480px !important;
     }
+    .toggle_min_lookup {
+      margin-left: -480px !important;
+    }
     .machine_name {
       width: 405px;
       margin-left: -10px;

--- a/app/assets/stylesheets/mediaqueries.css
+++ b/app/assets/stylesheets/mediaqueries.css
@@ -43,8 +43,8 @@
     #form input.lookup_search_input {
       width: 200px;
     }
-    #mapFollow_wrapper, #search_link_wrapper {
-      left: 480px;
+    .toggle_btn_reg {
+      left: 480px !important;
     }
     .machine_name {
       width: 405px;
@@ -64,9 +64,6 @@
       width: 340px;
       max-width: 340px;
       min-width: 340px;
-    }
-    #map {
-      left: 470px;
     }
     li.address_full, a.website, li.phone {
       width: auto;

--- a/app/assets/stylesheets/mobile-application.css.erb
+++ b/app/assets/stylesheets/mobile-application.css.erb
@@ -398,7 +398,7 @@ div.pick_a_map {
   top: 0;
   right: 0;
   position: relative;
-  margin: 10px;
+  margin: 10px !important;
   z-index: 0;
   padding-bottom: 5px;
   padding-top: 0;

--- a/app/assets/stylesheets/mobile-application.css.erb
+++ b/app/assets/stylesheets/mobile-application.css.erb
@@ -1,6 +1,7 @@
 #map_canvas {
   height: 100% !important;
   overflow: hidden !important;
+  margin-right: 0;
 }
 #page {
   height: 30px;
@@ -303,7 +304,7 @@ div.pick_a_map {
   position: relative;
   width: auto;
   min-width: 300px;
-  height: 300px;
+  height: 360px;
   left: 0;
   margin: 0 10px 10px;
   top: 0;
@@ -511,6 +512,9 @@ span.or {
   border-bottom-left-radius: 0;
   -webkit-border-bottom-left-radius: 0;
   -moz-border-bottom-left-radius: 0;
+}
+.toggle_btn_reg {
+  left: 0 !important;
 }
 
 .location_link {
@@ -1098,4 +1102,39 @@ p.notice {
 }
 .read_more_wrap {
   display: none;
+}
+
+/* map api */
+
+.gm-style div:first-child,
+.gm-style div:nth-child(3),
+.gm-style div:nth-child(9),
+.gm-style div:nth-child(10) {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+.gm-style div:nth-child(7),
+.gm-style  div:nth-child(9) {
+  margin-right: 10px !important;
+}
+.gm-style  div:nth-child(9) {
+  margin-right: 0 !important;
+  margin-bottom: 0 !important;
+}
+.gm-style div:nth-child(10) {
+  margin-left: 10px !important;
+  margin-bottom: 30px !important;
+
+}
+ .gm-style div:nth-child(4) {
+  right: 0 !important;
+  bottom: 0 !important;
+} 
+.gm-style div:nth-child(6) {
+  right: 0 !important;
+  bottom: 0 !important;
+}
+.gm-style div:nth-child(8) {
+  right: 28px !important;
+  bottom: 107px !important;
 }

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -35,13 +35,6 @@
 
       = yield
       :javascript
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-33321299-1', 'pinballmap.com');
-        ga('send', 'pageview');
 
         $(function () {
           hs.registerOverlay({

--- a/app/views/locations/_form.html.haml
+++ b/app/views/locations/_form.html.haml
@@ -34,13 +34,22 @@
               $('#by_#{key}_id').val(ui.item.id);
             });
           });
-#mapFollow_wrapper.hide_button
+- if !mobile_device?
+  #min_lookup_wrapper.hide_button.slide_left.toggle_btn_reg{:onclick => "min_lookup()"}
+#mapFollow_wrapper.hide_button.toggle_btn_reg
   %input{:type => "checkbox", :id => "followCheck", :name => "followCheck", :onchange => 'unChecked();'}
   Redo results when map is moved?
-#search_link_wrapper.hide_button
+#search_link_wrapper.hide_button.toggle_btn_reg
   =link_to "Link to this Search Result", "", :id => "search_link"
-
 :javascript
+  
+  function min_lookup() {
+    $("#lookup,#form").toggleClass("toggle_min_lookup");
+    $("#lookup,#form").toggleClass("toggle_reg_lookup");
+    $("#min_lookup_wrapper").toggleClass("slide_left slide_right");
+    $("#mapFollow_wrapper, #search_link_wrapper, #min_lookup_wrapper").toggleClass("toggle_map_btn");
+    $("#mapFollow_wrapper, #search_link_wrapper, #min_lookup_wrapper").toggleClass("toggle_btn_reg");
+  }
 
   $(function () {
 

--- a/app/views/locations/_locations.html.haml
+++ b/app/views/locations/_locations.html.haml
@@ -3,7 +3,7 @@
 
     clearMarkers()
     clearInfoWindows();
-    $("#mapFollow_wrapper,#search_link_wrappers").removeClass("hide_button");
+    $("#mapFollow_wrapper,#search_link_wrapper,#min_lookup_wrapper").removeClass("hide_button");
 
     var hrefOrig = 'https://#{request.host_with_port}/#{@region.name.downcase}?';
     var def_value = window.location.href;

--- a/app/views/pages/region.html.haml
+++ b/app/views/pages/region.html.haml
@@ -1,9 +1,10 @@
 #region_page_body
-  #map
-    = render :partial => 'locations/map'
-  #form
+  #form.toggle_reg_lookup
     = render :partial => 'locations/form'
-  #lookup
+  - if mobile_device?
+    #map
+      = render :partial => 'locations/map'
+  #lookup.toggle_reg_lookup
     #locations
       = render :partial => 'pages/intro'
       - if !@region.motd.blank?
@@ -11,3 +12,6 @@
           %span.darkb Message of the Day:
           = @region.html_motd
       = yield :presearch_sidebar
+  - if !mobile_device?
+    #map
+      = render :partial => 'locations/map'


### PR DESCRIPTION
This is a really minor thing that was probably more work than it was worth.
On desktop, when you load results, there's a "< more map" button. When clicked, the form/lookup shifts to the left, and the button becomes "> less map". Clicking it brings the form/lookup back. The javascript is VERY simple. At first I had speed included in the toggleClass function, but it only worked well in one direction. So instead, I put the transition animation in the css: `transition:all 0.5s ease-in-out;` But this required adding another class to each div for the regular state (so it had something to ease back into).

Another change is that the map is now full screen. Before it had a margin-left the width of the form/lookup. In css, I shifted the center of the map so it's in the middle of the visible area. This then required hardcoding all the stupid google maps attribute metadata.

On mobile, I made a couple small changes: map is a little higher. And the lookup form is above it. 
