### PR TITLE
remove portland admin link on about page

### DIFF
--- a/app/views/pages/about.html.haml
+++ b/app/views/pages/about.html.haml
@@ -9,10 +9,6 @@
           the
           = @region.full_name
           Pinball Map administrator
-      %p
-        (or
-        = link_to 'click here', about_path('portland')
-        to contact the Pinball Map creators)
       #contact_maker
         = form_tag contact_sent_path, :method => 'get' do
           %ul


### PR DESCRIPTION
My postgresql upgraded, and I haven't upgraded the database yet. So I didn't verify that this works on my local. But it's a very simple commit and should be fine!