### PR TITLE
add zone dropdown to location suggestion form - nonfunctioning; hide …

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -109,6 +109,9 @@ class PagesController < ApplicationController
 
     @operators = Operator.where(['region_id = ?', @region.id]).map(&:name).uniq.sort
     @operators.unshift('')
+
+    @zones = Zone.where(['region_id = ?', @region.id]).map(&:name).uniq.sort
+    @zones.unshift('')
   end
 
   def robots

--- a/app/views/pages/suggest_new_location.html.haml
+++ b/app/views/pages/suggest_new_location.html.haml
@@ -31,9 +31,15 @@
               %li
                 %label{:for => "location_type"} Location Type:
                 = select_tag :location_type, options_for_select(@location_types)
-              %li
-                %label{:for => "location_operator"} Operator:
-                = select_tag :location_operator, options_for_select(@operators)
+              - if @operators.size > 1
+                %li{:class => "first"}
+                  %label{:for => "location_operator"} Operator:
+                  = select_tag :location_operator, options_for_select(@operators)
+              - if @zones.size > 1
+                %li
+                  %label{:for => "locations_zone"} Zone:
+                  = select_tag :location_zone, options_for_select(@zones)
+              .clear
               %li.textbox
                 %label{:for => "location_comments"} Comments:
                 %textarea{:type => "text", :name => "location_comments", :params => "location_comments", :class => "text"}


### PR DESCRIPTION
…zone, operator if none.

This is just the front-end part. The form fails when you submit it. So, don't deploy this until https://github.com/scottwainstock/pbm/issues/790 is complete (whatever needs to be done to get the form to work, and "zone" to be included in the email and suggested location, etc)
