### PR TITLE
include regionless link for the global rss feed

### DIFF
--- a/app/views/location_machine_xrefs/index.rss.builder
+++ b/app/views/location_machine_xrefs/index.rss.builder
@@ -10,10 +10,8 @@ xml.rss version: '2.0' do
       machine = cloned_lmx.machine
       location = cloned_lmx.location
       xml.item do
-        xml.title "#{machine.name} #{machine.year_and_manufacturer} was added to #{location.name} in #{location.city} #{cloned_lmx.last_updated_by_username.empty? ? '' : 'by ' + cloned_lmx.last_updated_by_username}"
-        if @region
-          xml.link [request.protocol, request.host_with_port, region_homepage_path(@region.name.downcase), "/?by_location_id=#{location.id}"].join('')
-        end
+        xml.title "#{machine.name} #{machine.year_and_manufacturer} was added to #{location.name} in #{location.city} #{cloned_lmx.last_updated_by_username.empty? ? '' : 'by ' + cloned_lmx.last_updated_by_username}" 
+        xml.link [request.protocol, request.host_with_port, @region ? region_homepage_path(@region.name.downcase) : '/regionless', "/?by_location_id=#{location.id}"].join('')
         xml.description "Added on #{cloned_lmx.created_at.nil? ? 'UNKNOWN' : cloned_lmx.created_at.to_s(:rfc822)}"
         xml.guid cloned_lmx.id, isPermaLink: false
         xml.pubDate cloned_lmx.created_at.nil? ? 'UNKNOWN' : cloned_lmx.created_at.to_s(:rfc822)


### PR DESCRIPTION
right now the logic is like, "if the RSS feed link is for a region, then the rss item links will include that region. If not, then they'll all use /regionless. But it would be cool if the logic was, "if RSS item is for a location that's within a region, then show that region in url." 

Does that make sense? I can't figure out how to do that.