### PR TITLE
Return emtpy array if no results from autocomplete_city

### DIFF
--- a/app/controllers/api/v1/locations_controller.rb
+++ b/app/controllers/api/v1/locations_controller.rb
@@ -243,7 +243,7 @@ module Api
         locations = Location.select { |l| l.city.tr('’', "'") =~ /#{Regexp.escape params[:name].tr('’', "'") || ''}/i }.sort_by(&:city).map { |l| { label: "#{l.city} #{l.state}", value: "#{l.city} #{l.state}" } }
 
         return_response(
-          locations.uniq!,
+          locations.uniq,
           nil,
           []
         )

--- a/spec/requests/api/v1/locations_controller_spec.rb
+++ b/spec/requests/api/v1/locations_controller_spec.rb
@@ -704,6 +704,16 @@ HERE
 [{"label":"Portland OR","value":"Portland OR"},{"label":"Portland ME","value":"Portland ME"}]
 HERE
     end
+
+    it 'should return an emtpy array if no found results' do
+      FactoryBot.create(:location, city: 'Portland', state: 'ME')
+      FactoryBot.create(:location, city: 'Portland', state: 'OR')
+      FactoryBot.create(:location, city: 'Beaverton')
+
+      get '/api/v1/locations/autocomplete_city', params: { name: 'asdf' }
+
+      expect(response.body).to eq('[]')
+    end    
   end
 
   describe '#autocomplete' do
@@ -717,6 +727,16 @@ HERE
       expect(response.body).to eq(<<HERE.strip)
 [{"label":"bar (Portland, OR)","value":"bar","id":#{bar.id}},{"label":"barfoo (Portland, OR)","value":"barfoo","id":#{barfoo.id}}]
 HERE
+    end
+
+    it 'should return an emtpy array if no found results' do
+      FactoryBot.create(:location, name: 'foo')
+      bar = FactoryBot.create(:location, name: 'bar')
+      barfoo = FactoryBot.create(:location, name: 'barfoo')
+    
+      get '/api/v1/locations/autocomplete', params: { name: 'asdf' }
+    
+      expect(response.body).to eq('[]')
     end
 
     it 'handles normal and iOS apostrophes' do


### PR DESCRIPTION
#1147 is returning null if no results come back from autocomplete_city. It is easier to deal with an empty array coming back in the app. 

Looking at the documentation for `uniq!` vs `uniq`, `uniq` seems more appropriate for our needs as it returns an array if no results as well as no duplicates are found. 