### PR TITLE
add recaptcha to devise signup

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,3 +1,28 @@
 class RegistrationsController < Devise::RegistrationsController
   respond_to :json
+  prepend_before_action :create, only: [:create]
+  
+  def create
+    if verify_recaptcha
+      @user = User.new(user_params)
+        if @user.save
+          redirect_to root_path, notice: "Great! Now confirm your account. A confirmation link has been sent to your email address."
+        else
+          render action: 'new'
+        end
+    else
+      build_resource(sign_up_params)
+      clean_up_passwords(resource)
+      flash.now[:alert] = "Your captcha entering skills have failed you. Please go back and try again."
+      flash.delete :recaptcha_error
+      render :new
+    end
+  end
+  
+  private
+
+  def user_params
+    params.require(:user).permit(:email, :password, :password_confirmation, :remember_me, :region_id, :is_machine_admin, :is_primary_email_contact, :username, :is_disabled, :is_super_admin)
+  end
+  
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -25,6 +25,7 @@
 					<%= f.input :password, :required => true %>
 					<%= f.input :password_confirmation, :required => true %>
 				</div>
+				<div class="recaptcha" style="clear:both"><%= recaptcha_tags %></div>
 				<div class="form-actions">
 					<%= f.button :submit, "Join" %>
 				</div>

--- a/app/views/pages/store.html.haml
+++ b/app/views/pages/store.html.haml
@@ -21,7 +21,7 @@
         Both designs are by the talented 
         = link_to 'Drew Marshall.', 'https://workbydrew.com', :target => "_blank", :class => "bold"
         They come in sizes S - XXL, unisex, on All Style brand shirts (similar to Gildan).
-      %p.red.bold NOTE: We are all out of XL in the classic style!
+      %p.red.bold NOTE: We are all out of X-Large and Small in the classic style!
       %p.serif
         The shirts are $19, plus $3 shipping for domestic orders. If you are a 
         = link_to "Pinball Map Patreon", "https://patreon.com/pinballmap", :class => "bold"
@@ -44,7 +44,6 @@
             %tr{:align => 'center'}
               %td
                 %select{:name => "os0"}
-                  %option{:value => "Small"} Small
                   %option{:value => "Medium"} Medium
                   %option{:value => "Large"} Large
                   %option{:value => "XX Large"} XX Large


### PR DESCRIPTION
This seems to work. But it could use your review.

And I tried to make a test for it, but couldn't get it to function right (although _one time_ it mysteriously passed).

My attempt (not committed):

````
require 'spec_helper'

describe RegistrationsController, type: :controller do

  describe 'create' do
    it 'should flash an error message if captcha fails' do
      expect(controller).to receive(:verify_recaptcha).and_return(nil)

      post 'create', params: { username: 'wizard', email: 'pinballwizard@foo.com', password: 'okokok', password_confirmation: 'okokok' }

      expect(request.flash[:alert]).to eq('Your captcha entering skills have failed you. Please go back and try again.')
    end
  end
end
````

error: 
````
  1) RegistrationsController create should flash an error message if captcha fails
     Failure/Error: build_resource(sign_up_params)
     
     NoMethodError:
       undefined method `to' for nil:NilClass
````