### PR TITLE
no details flag for closest_by_lat_lon endpoint, for app

### DIFF
--- a/spec/requests/api/v1/locations_controller_spec.rb
+++ b/spec/requests/api/v1/locations_controller_spec.rb
@@ -580,6 +580,29 @@ HERE
       expect(locations[1]['id']).to eq(close_location_two.id)
       expect(locations[2]['id']).to eq(close_location_three.id)
     end
+    
+    it 'respects no_details and shows fewer location fields' do
+      close_location_one = FactoryBot.create(:location, region: @region, lat: 45.49, lon: -122.63)
+      close_location_two = FactoryBot.create(:location, region: @region, lat: 45.49, lon: -122.631)
+      FactoryBot.create(:location, region: @region, lat: 5.49, lon: 22.63)
+      
+      get '/api/v1/locations/closest_by_lat_lon.json', params: { lat: close_location_one.lat, lon: close_location_one.lon, send_all_within_distance: 1, no_details: 1 }
+
+      expect(response.body.scan('country').size).to eq(0)
+      expect(response.body.scan('is_stern_army').size).to eq(0)
+      expect(response.body.scan('last_updated_by_user_id').size).to eq(0)
+      expect(response.body.scan('description').size).to eq(0)
+      expect(response.body.scan('region_id').size).to eq(0)
+      expect(response.body.scan('zone_id').size).to eq(0)
+      expect(response.body.scan('website').size).to eq(0)
+      expect(response.body.scan('phone').size).to eq(0)
+
+      expect(response.body.scan('id').size).to_not eq(0)
+      expect(response.body.scan('name').size).to_not eq(0)
+      expect(response.body.scan('lat').size).to_not eq(0)
+      expect(response.body.scan('lon').size).to_not eq(0)
+      expect(response.body.scan('city').size).to_not eq(0)
+    end
 
     it 'respects filters' do
       location_type = FactoryBot.create(:location_type)


### PR DESCRIPTION
@scottwainstock This is my first attempt at modifying the API. Tests pass, and I added a new test for this. But let me know if you see any red flags.

The app uses this endpoint to get locations on the map screen. My goal was to add a no_details flag to remove any locations fields that we aren't using on this screen - and then I want to see if this speeds up the app at all. I think the speed improvements would be small - but anything helps, I guess.

Sample endpoint:
http://localhost:3000/api/v1/locations/closest_by_lat_lon.json?lat=45.52819783271801;lon=-122.66291722170914;send_all_within_distance=10;no_details=1