### PR TITLE
Remove ability of users to add new machine names

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -355,3 +355,8 @@ var show_ajax_message = function(msg, type) {
     $("#flash-message").html('<div id="flash_'+type+'">'+msg+'</div>');
     fade_flash();
 };
+
+function show_new_machine_message() {
+    $("#flash-message").html('<div id="flash_alert">'+'Thank you. Since this is a new machine name, we are moderating this submission.'+'</div>');
+    fade_flash();
+};

--- a/app/controllers/api/v1/machines_controller.rb
+++ b/app/controllers/api/v1/machines_controller.rb
@@ -41,7 +41,6 @@ module Api
           machine = Machine.create(name: machine_name)
 
           send_new_machine_notification(machine, location, current_user.nil? ? nil : current_user)
-          return_response(machine, 'machine', [], [], 201)
         else
           return_response('Machine already exists', 'errors')
         end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,6 +34,8 @@ class ApplicationController < ActionController::Base
   end
 
   def send_new_machine_notification(machine, location, user)
+    render js: 'show_new_machine_message();'
+
     user_info = user ? " by #{user.username} (#{user.email})" : ''
 
     Pony.mail(

--- a/app/controllers/location_machine_xrefs_controller.rb
+++ b/app/controllers/location_machine_xrefs_controller.rb
@@ -16,9 +16,9 @@ class LocationMachineXrefsController < InheritedResources::Base
       if machine.nil?
         machine = Machine.new
         machine.name = params["add_machine_by_name_#{location.id}"]
-        machine.save
 
         send_new_machine_notification(machine, location, user)
+        return
       end
     else
       # blank submit

--- a/app/views/pages/faq.html.haml
+++ b/app/views/pages/faq.html.haml
@@ -6,7 +6,42 @@
         On this page, we'll respond to some frequently asked questions (and frequently commented comments). If you have a question or comment,
         = link_to 'contact us.', about_path('portland')
     .column.w_560.mt_5
-      %p.question You should add Johndoeville to your app.
+      %p.question This machine is no longer at this location.
+      %ul.answer
+        %li
+          This is a user-powered map, and YOU can remove the machine from the location. On the website, just click the "remove" button that's below the machine name. On the app, click on the machine name, and then look for a "remove" button or trash can icon.
+      %hr
+      %p.question This location closed/no longer has machines.
+      %ul.answer
+        %li
+          Simply remove all the machines from it. We get notified once a week about empty locations, and then we delete them (sometimes we wait longer to delete them because we want to verify that the machines are really gone). So, no need to tell us. But still, thanks for telling us and for updating the map!
+      %hr
+      %p.question Can you include 'bat games' like SlugFest on the map?
+      %ul.answer
+        %li
+          No. We used to include bat games, but found that non-pinball machines like that were a slippery slope toward including more and more non-pinball machines. We only want to map pinball machines. In general, if the machine is not listed on
+          = link_to 'OPDB', 'http://opdb.org'
+          then we will not include it.
+      %p.question Why was my comment removed?
+      %ul.answer
+        %li
+          Our moderators may deem your machine or location comment to be inappropriate because:
+        %br
+        %ul.bold
+          %li
+            It contains a personal attack
+          %li
+            It isn't relevant
+          %li
+            It is offensive
+          %li
+            It isn't constructive
+      %hr
+      %p.question Why was my account banned?
+      %ul.answer
+        %li
+        If we find that your account has been used to mess with data on the site, then we may ban it. Abusive behavior includes, but is not limited to: deleting machines that are at a location; adding machines that are not at a location; leaving lots of inappropriate/abusive comments.
+      %p.question You should add Johndoeville as a 'region' on the map.
       %ul.answer
         %li
           We can really only respond to this with our own questions:
@@ -30,7 +65,7 @@
               This is a user-powered map. It only works when many people are aware of it and updating it. And it's YOUR job to spread the word.
 
         %span.bold We can't add a new region without the answers to those questions!
-      %hr    
+      %hr
       %p.question Why didn't you add the region that I requested?
       %ul.answer
         Most likely, it's because you didn't answer the above questions.
@@ -61,33 +96,3 @@
           %br
           Admins should care about the integrity of the map. They should be careful and consistent with their spelling and punctuation. They should also have an interest in helping spread the word about the map. Each map is for the people who live in that area, and so admins are kind of an ambassador for their local map. They should also be unbiased - each map is a representation of what exists. Any user can leave a comment about a machine or location, so if a place sucks then it will be known. But it's not the admin's role to exclude places because they suck. All locations with publicly playable pinball should be on the map.
       %hr
-      %p.question This machine is no longer at this location.
-      %ul.answer
-        %li
-          This is a user-powered map, and YOU can remove the machine from the location. On the website, just click the "remove" button that's below the machine name. On the app, click on the machine name, and then look for a "remove" button or trash can icon.
-      %hr
-      %p.question This location closed/no longer has machines.
-      %ul.answer
-        %li
-          Simply remove all the machines from it. We get notified once a week about empty locations, and then we delete them (sometimes we wait longer to delete them because we want to verify that the machines are really gone). So, no need to tell us. But still, thanks for telling us and for updating the map!
-      %hr
-      %p.question Why was my comment removed?
-      %ul.answer
-        %li
-          Our moderators may deem your machine or location comment to be inappropriate because:
-          %br
-          %br
-          %ul.bold
-            %li
-              It contains a personal attack
-            %li
-              It isn't relevant
-            %li
-              It is offensive
-            %li
-              It isn't constructive
-      %hr
-      %p.question Why was my account banned?
-      %ul.answer
-        %li
-          If we find that your account has been used to mess with data on the site, then we may ban it. Abusive behavior includes, but is not limited to: deleting machines that are at a location; adding machines that are not at a location; leaving lots of inappropriate/abusive comments.

--- a/spec/features/location_machine_xrefs_controller_spec.rb
+++ b/spec/features/location_machine_xrefs_controller_spec.rb
@@ -84,7 +84,7 @@ describe LocationMachineXrefsController do
       expect(find("#show_machines_location_#{@location.id}")).to have_content(@machine_to_add.name)
     end
 
-    it 'Should add by name of new machine' do
+    it 'Should not add by name of new machine' do
       visit "/#{@region.name}/?by_location_id=#{@location.id}"
 
       find("#add_machine_location_banner_#{@location.id}").click
@@ -93,10 +93,9 @@ describe LocationMachineXrefsController do
 
       sleep 1
 
-      expect(@location.machines.size).to eq(1)
-      expect(@location.machines.first.name).to eq('New Machine Name')
+      expect(@location.machines.size).to eq(0)
 
-      expect(find("#show_machines_location_#{@location.id}")).to have_content('New Machine Name')
+      expect(find("#show_machines_location_#{@location.id}")).to_not have_content('New Machine Name')
     end
 
     it 'should display year/manufacturer where appropriate in dropdown' do

--- a/spec/requests/api/v1/machines_controller_spec.rb
+++ b/spec/requests/api/v1/machines_controller_spec.rb
@@ -105,8 +105,7 @@ describe Api::V1::MachinesController, type: :request do
 
       post '/api/v1/machines.json', params: { machine_name: 'Bawb', location_id: @location.id.to_s, user_email: 'foo@bar.com', user_token: '1G8_s7P-V-4MGojaKD7a' }
       expect(response).to be_successful
-      expect(response.status).to eq(201)
-      expect(JSON.parse(response.body)['machine']['name']).to eq('Bawb')
+      expect(response.status).to eq(200)
     end
 
     it 'handles creation by machine name.. new machine name - authed' do
@@ -121,8 +120,7 @@ describe Api::V1::MachinesController, type: :request do
 
       post '/api/v1/machines.json', params: { machine_name: 'Auth Bawb', location_id: @location.id.to_s, user_email: 'foo@bar.com', user_token: '1G8_s7P-V-4MGojaKD7a' }
       expect(response).to be_successful
-      expect(response.status).to eq(201)
-      expect(JSON.parse(response.body)['machine']['name']).to eq('Auth Bawb')
+      expect(response.status).to eq(200)
     end
   end
 end


### PR DESCRIPTION
Machines admins still get notified by email.
Flash messages states that the edit is moderated.
Couldn't get rails flash to work, but instead used js...