### PR TITLE
Display if operator does or does not receive machine comments in location metadata

### DIFF
--- a/app/assets/stylesheets/application.css.scss.erb
+++ b/app/assets/stylesheets/application.css.scss.erb
@@ -1603,6 +1603,9 @@ input.score {
   font-family: $serif;
   float: left;
 }
+.operator_comments {
+  padding: 0 10px 0;
+}
 .desc_button {
   color: $darkgrey;
   line-height: 20px;

--- a/app/views/locations/_render_update_metadata.html.haml
+++ b/app/views/locations/_render_update_metadata.html.haml
@@ -9,28 +9,31 @@
   - if l.website?
     %li.website= link_to "Website", l.website, :class => 'website', :target => 'blank'
     .clear
-  - if (l.operator_id) || (l.location_type)
-    - if (l.operator_id)
-      - if ((l.operator.website && l.operator.website.empty?) || (!l.operator.website))
-        %li.operator
-          %span.grey Operated by:
-          %span &nbsp;#{l.operator.name}
-        .clear
-      - else
-        %li.operator
-          %span.grey Operated by:
-          %span
-            =link_to "#{l.operator.name}", "#{l.operator.website}", :target => "_blank"
-        .clear
-    - if (l.location_type)
-      %li.location_type
-        %span.grey Location Type:
-        %span
-        - if l.region
-          =link_to "#{l.location_type.name}", "/#{l.region.name.downcase}?utf8=✓&by_type_id=#{l.location_type.id}"
-        - else
-          #{l.location_type.name}
+  - if (l.operator_id)
+    - if ((l.operator.website && l.operator.website.empty?) || (!l.operator.website))
+      %li.operator
+        %span.grey Operated by:
+        %span &nbsp;#{l.operator.name}
       .clear
+    - else
+      %li.operator
+        %span.grey Operated by:
+        %span
+          =link_to "#{l.operator.name}", "#{l.operator.website}", :target => "_blank"
+    - if (l.operator.operator_has_email)
+      %li.operator.operator_comments.location_actual_description (This operator receives machine comments)
+    - else
+      %li.operator.operator_comments.location_actual_description (This operator does not receive machine comments)
+  .clear
+  - if (l.location_type)
+    %li.location_type
+      %span.grey Location Type:
+      %span
+      - if l.region
+        =link_to "#{l.location_type.name}", "/#{l.region.name.downcase}?utf8=✓&by_type_id=#{l.location_type.id}"
+      - else
+        #{l.location_type.name}
+    .clear
   - if ((current_page?(map_location_data_path) || request.referer =~ /map/) && l.region)
     %li.location_type
       %span.grey Region:

--- a/spec/features/location_machine_xrefs_controller_spec.rb
+++ b/spec/features/location_machine_xrefs_controller_spec.rb
@@ -752,6 +752,7 @@ describe LocationMachineXrefsController do
 
       expect(page).to have_content('Cleo')
       expect(page).to have_link('Quarter Bean')
+      expect(page).to have_content("(This operator does not receive machine comments)")
 
       l = FactoryBot.create(:location, id: 44, region: @region, name: 'Sass', operator: FactoryBot.create(:operator, name: 'Sass Bean', region: @region, website: nil))
 
@@ -773,6 +774,14 @@ describe LocationMachineXrefsController do
       page.find('div#other_search_options button#operator_section_link').click
 
       expect(page).to have_select('by_operator_id', options: ['All', 'Quarter Bean'])
+    end
+
+    it 'displays message about operator receiving machine comments' do
+      FactoryBot.create(:location, id: 45, region: @region, name: 'Cleo', operator: FactoryBot.create(:operator, name: 'Quarter Bean', email: 'foo@bar.com', region: @region))
+
+      visit "/#{@region.name}?by_location_id=#{l.reload.id}"
+
+      expect(page).to have_content("(This operator receives machine comments)")
     end
 
     it 'displays location type for a location, if it is available' do


### PR DESCRIPTION
I attempted to also put it near the machine comment input box. But I don't think l.operator is available there.