### PR TITLE
Use Case to get user rank and admin title, show on profile page

### DIFF
--- a/app/assets/stylesheets/application.css.scss.erb
+++ b/app/assets/stylesheets/application.css.scss.erb
@@ -383,6 +383,53 @@ form.new_user .form-actions, form.edit_user .form-actions {
 
 /** Stats **/
 
+.rank_icon {
+  margin-bottom: -3px;
+  height: 15px;
+  width: 15px;
+}
+.rank_icon_1:hover:after,
+.rank_icon_2:hover:after,
+.rank_icon_3:hover:after,
+.rank_icon_4:hover:after,
+.rank_icon_5:hover:after {
+  position: absolute;
+  line-height: 14px;
+  font-size: 16px;
+  margin-left: 10px;
+  margin-top: -3px;
+  background: $black;
+  color: $lightgrey;
+  padding: 5px;
+  font-weight: $bold;
+  font-family: $sans;
+  text-align: center;
+}
+.rank_icon_1:hover:after {
+  content: "Global Administrator";
+  width: 180px;
+}
+.rank_icon_2:hover:after {
+  content: "Regional Administrator";
+  width: 190px;
+}
+.rank_icon_3:hover:after {
+  content: "Grand Champ Contributor";
+  width: 220px;
+}
+.rank_icon_4:hover:after {
+  content: "Legendary Contributor";
+  width: 190px;
+}
+.rank_icon_5:hover:after {
+  content: "Super Contributor";
+  width: 160px;
+}
+.profile_rank_icon {
+  margin-bottom: -5px;
+  height: 20px;
+  width: 20px;
+}
 div.stats {
   line-height: 22px;
   border-bottom: 1px solid $red;

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -188,7 +188,7 @@ module Api
           user,
           'profile_info',
           [],
-          %i[num_machines_added num_machines_removed num_locations_edited num_locations_suggested num_lmx_comments_left num_msx_scores_added profile_list_of_edited_locations profile_list_of_high_scores created_at]
+          %i[admin_rank_int admin_title contributor_rank_int contributor_rank num_total_submissions num_machines_added num_machines_removed num_locations_edited num_locations_suggested num_lmx_comments_left num_msx_scores_added profile_list_of_edited_locations profile_list_of_high_scores created_at]
         )
       rescue ActiveRecord::RecordNotFound
         return_response('Failed to find user', 'errors')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -145,6 +145,57 @@ class User < ApplicationRecord
     ).includes('location').order('created_at desc')
   end
 
+  def num_total_submissions
+    edited_location_submissions.size + num_locations_suggested
+  end
+
+  def contributor_rank_int
+    case num_total_submissions
+    when 0...50
+      nil
+    when 50...250
+      3
+    when 250...500
+      2
+    when 500...Float::INFINITY
+      1
+    end
+  end
+
+  def contributor_rank
+    case contributor_rank_int
+    when nil
+      nil
+    when 3
+      'Super Contributor'
+    when 2
+      'Legendary Contributor'
+    when 1
+      'Grand Champ Contributor'
+    end
+  end
+
+  def admin_rank_int
+    if region_id == 1 || username == 'pbm'
+      return 1
+    elsif !region_id.blank?
+      return 2
+    else
+      return nil
+    end
+  end
+
+  def admin_title
+    case admin_rank_int
+    when 1
+      'Global Administrator'
+    when 2
+      'Regional Administrator'
+    else
+      nil
+    end
+  end
+
   def as_json(options = {})
     super({ only: [:id] }.merge(options))
   end

--- a/app/views/users/profile.html.haml
+++ b/app/views/users/profile.html.haml
@@ -3,11 +3,26 @@
     .column.w_320.bg_gray.ta_c
       %p.red.font18.sans.bold
         =link_to @user.username, profile_user_path(@user.id)
+      - if @user.admin_rank_int
+        %p.red.bold.blue_bg.p_10.inline_block
+          #{@user.admin_title}
+          %span
+            =image_tag("rank/Rank_#{@user.admin_rank_int}.png", :class => "profile_rank_icon rank_icon_#{@user.admin_rank_int}")
+      - elsif @user.contributor_rank_int
+        %p.red.bold.blue_bg.p_10.inline_block
+          #{@user.contributor_rank}
+          %span
+            =image_tag("rank/Rank_#{@user.contributor_rank_int}.png", :class => "profile_rank_icon rank_icon_#{@user.contributor_rank_int}")
       %p.darkgrey{:style => "font-size:16px;"} Member since: #{@user.created_at.strftime('%b-%d-%Y')}
       - if current_user && (@user.id == current_user.id)
         %p
           =link_to "Update email or password", edit_user_registration_path
     .column.w_560.mt_5
+      %div.darkgrey.stats.font18.sans.bold
+        %div.stat_num_o
+          %span.stats
+            #{@user.num_total_submissions}
+        %span.stats_text Total Contributions
       %div.darkgrey.stats.font18.sans.bold
         %div.stat_num_o
           %span.stats


### PR DESCRIPTION
Ok, this seems better. Does not appear to have N+1 issues, or take longer to load the profile page or the profile_info.json.

Difference this time is that I separated out the admin_rank calculations from the contributor_rank calculations, and used CASE as much as possible.